### PR TITLE
feat: エンチャントを使用できないように

### DIFF
--- a/src/main/java/space/yurisi/universecorev2/event/EventManager.java
+++ b/src/main/java/space/yurisi/universecorev2/event/EventManager.java
@@ -2,6 +2,7 @@ package space.yurisi.universecorev2.event;
 
 import org.bukkit.Bukkit;
 import space.yurisi.universecorev2.UniverseCoreV2;
+import space.yurisi.universecorev2.event.player.InteractEvent;
 import space.yurisi.universecorev2.event.player.LoginEvent;
 
 public class EventManager {
@@ -11,5 +12,6 @@ public class EventManager {
 
     private void init(UniverseCoreV2 main) {
         Bukkit.getPluginManager().registerEvents(new LoginEvent(), main);
+        Bukkit.getPluginManager().registerEvents(new InteractEvent(), main);
     }
 }

--- a/src/main/java/space/yurisi/universecorev2/event/player/InteractEvent.java
+++ b/src/main/java/space/yurisi/universecorev2/event/player/InteractEvent.java
@@ -1,0 +1,32 @@
+package space.yurisi.universecorev2.event.player;
+
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerInteractEvent;
+
+public class InteractEvent implements Listener {
+
+    @EventHandler(priority = EventPriority.HIGH)
+    public void onInteract(PlayerInteractEvent event) {
+        Player player = event.getPlayer();
+
+        // 右クリックしたブロックデータが格納されている。
+        // オブジェクトだけでなく、空気に対しても反応するので注意
+        Block targetBlock = event.getClickedBlock();
+        if (targetBlock == null) {
+            return;
+        }
+
+        switch (targetBlock.getType()) {
+            case ENCHANTING_TABLE -> {
+                if (!player.hasPermission("space.yurisi.universecorev2.interactevent.enchanttable")) {
+                    event.setCancelled(true);
+                }
+            }
+        }
+    }
+
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -87,6 +87,10 @@ commands:
     usage: /lobby
 
 permissions:
+  # UniverseCoreV2
+  space.yurisi.universecorev2.interactevent.enchanttable:
+    default: op
+
   #SubPlugins
   #LevelSystem
   space.yurisi.levelsystem.addexp:


### PR DESCRIPTION
本来の予定にはなかったこととして `space.yurisi.universecorev2.interactevent.enchanttable` パーミッションを持つプレイヤーはエンチャントテーブルを使用できるようにしました. これは OP のみ持つことを想定しています