### PR TITLE
chore: 依存関係の更新を Bot に任せる

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Dependabot が依存関係に更新が入ると build.gradle を更新するプルリクエストを立ててくれるようになります ( 外部DBとの通信を持つ `org.flywaydb.flyway` などクリティカルな依存が多いのでそれらをアップデートできる意味で追加しました)

依存関係に脆弱性が発生したときのパッチとはまた違います

詳細: https://docs.github.com/ja/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates

----

Paper API の更新だけは Minecraft サーバーと合わなくなってしまうので更新するときは注意. それを防ぐ場合は [renovate](https://www.mend.io/renovate/) というものを使う必要があります

