### PR TITLE
Fix/universe land/invite

### DIFF
--- a/src/main/java/space/yurisi/universecorev2/subplugins/universeland/command/LandCommand.java
+++ b/src/main/java/space/yurisi/universecorev2/subplugins/universeland/command/LandCommand.java
@@ -139,11 +139,16 @@ public class LandCommand implements CommandExecutor, TabCompleter {
                     Message.sendWarningMessage(player, "[土地管理AI]", "現在いる場所は、あなたの土地ではないため招待できません");
                     return false;
                 }
-                Land dbland = database.getLandRepository().getLand(land.getId());
-                database.getLandPermissionRepository().createLandPermission(user, dbland);
 
-                Message.sendSuccessMessage(player, "[土地管理AI]", args[1] + " がこの土地を利用できるようになりました");
-                return false;
+                Land dbland = database.getLandRepository().getLand(land.getId());
+
+                try {
+                    database.getLandPermissionRepository().getLandPermission(user, dbland);
+                    Message.sendWarningMessage(player, "[土地管理AI]", args[1] + " は既にこの土地の共有権限を持っています");
+                } catch (LandPermissionNotFoundException e) {
+                    database.getLandPermissionRepository().createLandPermission(user, dbland);
+                    Message.sendSuccessMessage(player, "[土地管理AI]", args[1] + " がこの土地を利用できるようになりました");
+                }
             } catch (UserNotFoundException e) {
                 Message.sendErrorMessage(player, "[土地管理AI]", "ユーザーが見つかりませんでした");
                 return false;

--- a/src/main/resources/db/migration/V2024.10.06__alter_table_land_permissions.sql
+++ b/src/main/resources/db/migration/V2024.10.06__alter_table_land_permissions.sql
@@ -1,0 +1,3 @@
+use SpaceServerUniverse;
+
+ALTER TABLE land_permissions ADD UNIQUE(land_id, uuid);

--- a/src/main/resources/db/migration/V2024.10.06__alter_table_land_permissions.sql
+++ b/src/main/resources/db/migration/V2024.10.06__alter_table_land_permissions.sql
@@ -1,3 +1,5 @@
 use SpaceServerUniverse;
 
+DELETE FROM land_permissions WHERE id NOT IN ( SELECT MIN(id) FROM land_permissions GROUP BY land_id, uuid) );
+
 ALTER TABLE land_permissions ADD UNIQUE(land_id, uuid);


### PR DESCRIPTION
**※マイグレーションファイルを一つ追加しています**
制約がエラーでマイグレーションに失敗してしまう問題を避けるために、land_permissionsのland_idとuuidが重複しているものを削除するためのSQL文が書かれています。
マージする場合は、DBのバックアップを取ってから使用することをお勧めします