### PR TITLE
chore: テスト環境でリソースパックを必須に

### DIFF
--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -10,6 +10,8 @@ services:
       - MEMORY=2G
       - RCON_PASSWORD=${RCON_PASSWORD}
       - TZ=Asia/Tokyo
+      - RESOURCE_PACK=https://github.com/SpaceServerUniverse/UniverseResourcePack/releases/latest/download/UniverseResources.zip
+      - REQUIRE_RESOURCE_PACK=true
     ports:
       - "25565:25565" # When you want to connect to the minecraft server, you need to connect to the port 25565.
       - "25575:25575"


### PR DESCRIPTION
`/docker` ディレクトリで利用できるサーバーでリソースパックを必須化しました