### PR TITLE
fix: Developer グループのプレイヤーがテレポートイベント発火後飛行できない不具合の修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ SpaceServer Universe のコアプラグイン
 2. サーバーを起動し, `plugins/UniverseCoreV2/` に生成された `config.yml` を編集します。 ([設定方法](#discord-との連携))
 3. サーバーを起動する。
 
+## 依存関係
+
+UniverseCoreV2 は以下のプラグインの API を使用しているため, 起動時にこれらのプラグインを導入しておく必要があります.
+
+- [LuckPerms](https://luckperms.net/)
+
 ### Discord との連携
 
 1. [Discord Developer Portal](https://discord.com/developers/applications) でアプリケーションを作成します。

--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ dependencies {
     api "org.flywaydb:flyway-core:8.0.0"
     api "at.favre.lib:bcrypt:0.10.2"
     compileOnly 'io.papermc.paper:paper-api:1.21.1-R0.1-SNAPSHOT'
+    compileOnly 'net.luckperms:api:5.4'
     implementation "xyz.xenondevs.invui:invui:1.37"
 }
 

--- a/src/main/java/space/yurisi/universecorev2/UniverseCoreV2.java
+++ b/src/main/java/space/yurisi/universecorev2/UniverseCoreV2.java
@@ -3,6 +3,7 @@ package space.yurisi.universecorev2;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.Logger;
 import org.bukkit.plugin.java.JavaPlugin;
+import space.yurisi.universecorev2.api.LuckPermsWrapper;
 import space.yurisi.universecorev2.command.CommandManager;
 import space.yurisi.universecorev2.database.DatabaseConnector;
 import space.yurisi.universecorev2.event.EventManager;
@@ -29,6 +30,8 @@ public final class UniverseCoreV2 extends JavaPlugin {
     @Override
     public void onEnable() {
         instance = this;
+
+        new LuckPermsWrapper().initLuckPerms();
 
         ((Logger) LogManager.getRootLogger()).addFilter(new PasswordFilter());
         this.config = new Config(this);

--- a/src/main/java/space/yurisi/universecorev2/api/LuckPermsWrapper.java
+++ b/src/main/java/space/yurisi/universecorev2/api/LuckPermsWrapper.java
@@ -1,0 +1,36 @@
+package space.yurisi.universecorev2.api;
+
+import net.luckperms.api.LuckPerms;
+import net.luckperms.api.LuckPermsProvider;
+import net.luckperms.api.model.group.Group;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+import java.util.Objects;
+
+public class LuckPermsWrapper {
+
+    public void initLuckPerms() {
+        Bukkit.getServicesManager().getRegistration(LuckPermsWrapper.class);
+    }
+
+    public static boolean isUserInGroup(Player player, String group) {
+        return player.hasPermission("group." + group);
+    }
+
+    public static boolean isOfflineUserInGroup(String playerName, String group) {
+        return Objects.requireNonNull(Bukkit.getOfflinePlayer(playerName).getPlayer()).hasPermission("group." + group);
+    }
+
+    public static Group getLuckPermsGroup(String groupName) {
+        LuckPerms luckPerms = LuckPermsProvider.get();
+        Group result = luckPerms.getGroupManager().getGroup(groupName);
+
+        if (result == null) {
+            throw new NullPointerException("Group not found");
+        }
+
+        return result;
+    }
+
+}

--- a/src/main/java/space/yurisi/universecorev2/event/player/TeleportEvent.java
+++ b/src/main/java/space/yurisi/universecorev2/event/player/TeleportEvent.java
@@ -7,6 +7,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.scheduler.BukkitRunnable;
+import space.yurisi.universecorev2.api.LuckPermsWrapper;
 
 public class TeleportEvent implements Listener {
 
@@ -19,19 +20,14 @@ public class TeleportEvent implements Listener {
     @EventHandler
     public void onTeleport(PlayerTeleportEvent event) {
         Player player = event.getPlayer();
-        Boolean allowFlight = false;
-        if(player.isOp() && !(player.getGameMode() == GameMode.SURVIVAL)){
-            allowFlight = true;
-        }
-        if(event.getTo().getWorld().getName().equals("lobby")){
-            allowFlight = true;
-        }
-        Boolean finalAllowFlight = allowFlight;
+        boolean allowFlight = player.isOp() && player.getGameMode() != GameMode.SURVIVAL
+                || LuckPermsWrapper.isUserInGroup(player, "developer")
+                || event.getTo().getWorld().getName().equals("lobby");
 
         new BukkitRunnable() {
             @Override
             public void run() {
-                player.setAllowFlight(finalAllowFlight);
+                player.setAllowFlight(allowFlight);
             }
         }.runTaskLater(plugin, 10);
     }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,6 +2,8 @@ name: UniverseCoreV2
 version: '1.0'
 main: space.yurisi.universecorev2.UniverseCoreV2
 api-version: '1.21'
+depend:
+  - LuckPerms
 commands:
   menu:
     description: メニューを開きます


### PR DESCRIPTION
- `isOp()` で検出できない `Developer` グループのプレイヤーがテレポートイベント発火後に飛行できなくなってしまう問題を修正.
- **マージ後に全開発者に LuckPerms を入れないと起動しないことを伝える必要アリ**