### PR TITLE
feat!: Support v1.21.3 (v1.21.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,12 @@
 
 SpaceServer Universe のコアプラグイン
 
+**Support: Minecraft 1.21.3**
+
 ## 使い方
 
 1. `plugins/` に `UniverseCoreV2.jar` を配置します。
-2. サーバーを起動し, `plugins/UniverseCoreV2/` に生成された `config.yml` を編集します。 ([設定方法](#discord-との連携))
+2. [LuckPerms](https://luckperms.net/) を導入します。
 3. サーバーを起動する。
 
 ## 依存関係
@@ -24,12 +26,11 @@ UniverseCoreV2 は以下のプラグインの API を使用しているため, �
    - `Public Bot` -> 無効 (あなた以外のユーザーが Bot を追加できないようにするため)
    - `Message Content Intent` -> 有効 (メッセージの内容を取得するため)
 3. Bot をギルドに招待します。
-4. `config.yml` に以下の設定を追加します。
+4. `UniverseCoreV2/subplugins/universe-discord.yml` に以下の設定を追加します。
    ```yaml
-   universe-discord:
-     token: ""
-     guild-id: ""
-     channel-id: ""
+   token: ""
+   guild-id: ""
+   channel-id: ""
    ```
 5. サーバーを再起動します。
 

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     api "com.mysql:mysql-connector-j:8.0.32"
     api "org.flywaydb:flyway-core:8.0.0"
     api "at.favre.lib:bcrypt:0.10.2"
-    compileOnly 'io.papermc.paper:paper-api:1.21.1-R0.1-SNAPSHOT'
+    compileOnly 'io.papermc.paper:paper-api:1.21.3-R0.1-SNAPSHOT'
     compileOnly 'net.luckperms:api:5.4'
     implementation "xyz.xenondevs.invui:invui:1.37"
 }


### PR DESCRIPTION
**まだマージしないでください. このプルリクエストは不安定です**

----

- Paper に [1.21.3 のパッチ](https://papermc.io/downloads/paper)が来ました (またアルファ段階です)
- プラグインは 1.21.3 の API でビルドが通ったのでおそらく動作はします (テストはしてません)
- 1.21.1 のサポートは切られることはないと思いますが, Paper は過去バージョンのサポートをしないのでいつかはアップデートしないといけないと思います

----

### Tasks

- [ ] Paper 1.21.3 環境での全機能テスト
- [ ] 他プラグイン対応状況の調査 (別途見出し確認)

----

### Other Plugins

- [ ] [CoreProtect](https://github.com/PlayPro/CoreProtect/) (2024/11/01現在, 未対応)
- [ ] [LuckPerms](https://github.com/LuckPerms/LuckPerms) (対応済み)
- [ ] [OpenInv](https://github.com/Jikoo/OpenInv) (対応済み)
- [ ] [FAWE](https://github.com/IntellectualSites/FastAsyncWorldEdit) (未確認)