### PR TITLE
Dev/gun meyason

### DIFF
--- a/src/main/java/space/yurisi/universecorev2/item/UniverseItem.java
+++ b/src/main/java/space/yurisi/universecorev2/item/UniverseItem.java
@@ -52,6 +52,7 @@ public class UniverseItem {
         items.put(M1911.id, new M1911());
         items.put(MagazineBag.id, new MagazineBag());
         items.put(TacticalLeggings.id, new TacticalLeggings());
+        items.put(TacticalVest.id, new TacticalVest());
         items.put(MainMenuBook.id, new MainMenuBook());
     }
 

--- a/src/main/java/space/yurisi/universecorev2/item/gun/F2.java
+++ b/src/main/java/space/yurisi/universecorev2/item/gun/F2.java
@@ -19,6 +19,7 @@ public final class F2 extends Gun {
         );
 
         this.type = GunType.AR;
+        this.equipmentType = GunType.PRIMARY;
         this.magazineSize = 30;
         this.burst = 2;
         this.reloadTime = 3500;

--- a/src/main/java/space/yurisi/universecorev2/item/gun/Gun.java
+++ b/src/main/java/space/yurisi/universecorev2/item/gun/Gun.java
@@ -11,6 +11,7 @@ import org.jetbrains.annotations.NotNull;
 import space.yurisi.universecorev2.UniverseCoreV2;
 import space.yurisi.universecorev2.constants.UniverseItemKeyString;
 import space.yurisi.universecorev2.item.CustomItem;
+import space.yurisi.universecorev2.item.UniverseItem;
 import space.yurisi.universecorev2.subplugins.universeguns.constants.GunType;
 
 import java.util.List;
@@ -209,7 +210,7 @@ public abstract class Gun extends CustomItem {
         return lore;
     }
 
-    public static boolean isGun(ItemStack itemStack){
+    public static Gun getGun(ItemStack itemStack){
         ItemMeta meta = itemStack.getItemMeta();
 
         PersistentDataContainer container = meta.getPersistentDataContainer();
@@ -222,8 +223,13 @@ public abstract class Gun extends CustomItem {
                 || !container.has(gunKey, PersistentDataType.BOOLEAN)
                 || !container.has(gunSerialKey, PersistentDataType.STRING)
         ){
-            return false;
+            return null;
         }
-        return true;
+        String itemID = container.get(itemKey, PersistentDataType.STRING);
+        CustomItem item = UniverseItem.getItem(itemID);
+        if((item instanceof Gun gun)){
+            return gun;
+        }
+        return null;
     }
 }

--- a/src/main/java/space/yurisi/universecorev2/item/gun/Gun.java
+++ b/src/main/java/space/yurisi/universecorev2/item/gun/Gun.java
@@ -178,7 +178,7 @@ public abstract class Gun extends CustomItem {
             case SG:
                 category += "ショットガン";
                 break;
-            case SR:
+            case SR, SR_SEMI, SR_BOLT:
                 category += "スナイパーライフル";
                 break;
             case HG:

--- a/src/main/java/space/yurisi/universecorev2/item/gun/Gun.java
+++ b/src/main/java/space/yurisi/universecorev2/item/gun/Gun.java
@@ -20,6 +20,8 @@ public abstract class Gun extends CustomItem {
 
     protected GunType type;
 
+    protected GunType equipmentType;
+
     protected int magazineSize;
 
     protected int burst;
@@ -69,6 +71,10 @@ public abstract class Gun extends CustomItem {
 
     public GunType getType(){
         return this.type;
+    }
+
+    public GunType getEquipmentType(){
+        return this.equipmentType;
     }
 
     public int getMagazineSize(){
@@ -184,8 +190,18 @@ public abstract class Gun extends CustomItem {
                 category += "特殊系";
                 break;
         }
+        String equipmentCategory = "§7装備カテゴリ: ";
+        switch (equipmentType){
+            case PRIMARY:
+                equipmentCategory += "プライマリ";
+                break;
+            case SECONDARY:
+                equipmentCategory += "セカンダリ";
+                break;
+        }
         List<Component> lore = List.of(
                 Component.text(category),
+                Component.text(equipmentCategory),
                 Component.text("§7マガジンサイズ: " + magazineSize),
                 Component.text("§7リロード時間: " + (double)reloadTime/1000 + "s"),
                 Component.text(flavorText)

--- a/src/main/java/space/yurisi/universecorev2/item/gun/L96A1.java
+++ b/src/main/java/space/yurisi/universecorev2/item/gun/L96A1.java
@@ -17,7 +17,7 @@ public final class L96A1 extends Gun {
                 ItemStack.of(Material.DIAMOND_HOE)
         );
 
-        this.type = GunType.SR;
+        this.type = GunType.SR_SEMI;
         this.equipmentType = GunType.PRIMARY;
         this.magazineSize = 5;
         this.burst = 0;

--- a/src/main/java/space/yurisi/universecorev2/item/gun/L96A1.java
+++ b/src/main/java/space/yurisi/universecorev2/item/gun/L96A1.java
@@ -18,6 +18,7 @@ public final class L96A1 extends Gun {
         );
 
         this.type = GunType.SR;
+        this.equipmentType = GunType.PRIMARY;
         this.magazineSize = 5;
         this.burst = 0;
         this.reloadTime = 5000;

--- a/src/main/java/space/yurisi/universecorev2/item/gun/M1911.java
+++ b/src/main/java/space/yurisi/universecorev2/item/gun/M1911.java
@@ -19,6 +19,7 @@ public final class M1911 extends Gun {
         );
 
         this.type = GunType.HG;
+        this.equipmentType = GunType.SECONDARY;
         this.magazineSize = 7;
         this.burst = 0;
         this.reloadTime = 800;

--- a/src/main/java/space/yurisi/universecorev2/item/gun/M870.java
+++ b/src/main/java/space/yurisi/universecorev2/item/gun/M870.java
@@ -19,6 +19,7 @@ public final class M870 extends Gun {
         );
 
         this.type = GunType.SG;
+        this.equipmentType = GunType.PRIMARY;
         this.magazineSize = 7;
         this.burst = 0;
         this.reloadTime = 4000;

--- a/src/main/java/space/yurisi/universecorev2/item/gun/R4C.java
+++ b/src/main/java/space/yurisi/universecorev2/item/gun/R4C.java
@@ -18,6 +18,7 @@ public final class R4C extends Gun {
         );
 
         this.type = GunType.AR;
+        this.equipmentType = GunType.PRIMARY;
         this.magazineSize = 30;
         this.burst = 0;
         this.reloadTime = 2500;

--- a/src/main/java/space/yurisi/universecorev2/item/gun/RPG.java
+++ b/src/main/java/space/yurisi/universecorev2/item/gun/RPG.java
@@ -19,6 +19,7 @@ public final class RPG extends Gun {
         );
 
         this.type = GunType.EX;
+        this.equipmentType = GunType.PRIMARY;
         this.magazineSize = 1;
         this.burst = 0;
         this.reloadTime = 10000;

--- a/src/main/java/space/yurisi/universecorev2/item/gun/SMG11.java
+++ b/src/main/java/space/yurisi/universecorev2/item/gun/SMG11.java
@@ -18,6 +18,7 @@ public final class SMG11 extends Gun {
         );
 
         this.type = GunType.SMG;
+        this.equipmentType = GunType.SECONDARY;
         this.magazineSize = 16;
         this.burst = 0;
         this.reloadTime = 800;

--- a/src/main/java/space/yurisi/universecorev2/item/gun/TacticalVest.java
+++ b/src/main/java/space/yurisi/universecorev2/item/gun/TacticalVest.java
@@ -5,40 +5,39 @@ import org.bukkit.Color;
 import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.LeatherArmorMeta;
 import space.yurisi.universecorev2.item.CustomItem;
 
 import java.util.List;
 import java.util.Random;
 
-public class TacticalLeggings extends CustomItem {
+public class TacticalVest extends CustomItem {
 
-    public static final String id = "tactical_leggings";
+    public static final String id = "tactical_vest";
 
-    public TacticalLeggings() {
+    public TacticalVest() {
         super(
                 id,
-                "§dタクティカルレギンス",
-                ItemStack.of(Material.LEATHER_LEGGINGS)
+                "§dタクティカルベスト",
+                ItemStack.of(Material.LEATHER_CHESTPLATE)
         );
     }
 
     @Override
     protected void registerItemFunction() {
         default_setting = (item) -> {
-            LeatherArmorMeta meta = (LeatherArmorMeta) item.getItemMeta();
-            if (meta != null) {
-                meta.addEnchant(Enchantment.UNBREAKING, 4, true);
+            LeatherArmorMeta leatherMeta = (LeatherArmorMeta) item.getItemMeta();
+            if (leatherMeta != null) {
+                leatherMeta.addEnchant(Enchantment.UNBREAKING, 4, true);
                 List<Component> lore = List.of(
-                        Component.text("§7マガジンを取り出しやすくした戦闘用のレギンス"),
-                        Component.text("§7装備することでリロード速度が上昇する")
+                        Component.text("§7銃やマガジンを装備するアタッチメントのあるベスト"),
+                        Component.text("§7リロード速度上昇とセカンダリの所持枠が§d1§7増加")
                 );
-                meta.lore(lore);
+                leatherMeta.lore(lore);
                 Random random = new Random();
                 Color colour = Color.fromRGB(random.nextInt(256), random.nextInt(256), random.nextInt(256));
-                meta.setColor(colour);
-                item.setItemMeta(meta);
+                leatherMeta.setColor(colour);
+                item.setItemMeta(leatherMeta);
             }
             return item;
         };

--- a/src/main/java/space/yurisi/universecorev2/item/gun/TacticalVest.java
+++ b/src/main/java/space/yurisi/universecorev2/item/gun/TacticalVest.java
@@ -31,8 +31,8 @@ public class TacticalVest extends CustomItem {
                 leatherMeta.addEnchant(Enchantment.UNBREAKING, 4, true);
                 List<Component> lore = List.of(
                         Component.text("§7銃やマガジンを装備するアタッチメントのあるベスト"),
-//                        Component.text("§7リロード速度上昇とセカンダリの所持枠が§d1§7増加")
-                        Component.text("§7リロード速度上昇")
+                        Component.text("§7リロード速度上昇とセカンダリの所持枠が§d1§7増加")
+//                        Component.text("§7リロード速度上昇")
                 );
                 leatherMeta.lore(lore);
                 Random random = new Random();

--- a/src/main/java/space/yurisi/universecorev2/item/gun/TacticalVest.java
+++ b/src/main/java/space/yurisi/universecorev2/item/gun/TacticalVest.java
@@ -31,7 +31,8 @@ public class TacticalVest extends CustomItem {
                 leatherMeta.addEnchant(Enchantment.UNBREAKING, 4, true);
                 List<Component> lore = List.of(
                         Component.text("§7銃やマガジンを装備するアタッチメントのあるベスト"),
-                        Component.text("§7リロード速度上昇とセカンダリの所持枠が§d1§7増加")
+//                        Component.text("§7リロード速度上昇とセカンダリの所持枠が§d1§7増加")
+                        Component.text("§7リロード速度上昇")
                 );
                 leatherMeta.lore(lore);
                 Random random = new Random();

--- a/src/main/java/space/yurisi/universecorev2/subplugins/changemessages/event/player/DeathEvent.java
+++ b/src/main/java/space/yurisi/universecorev2/subplugins/changemessages/event/player/DeathEvent.java
@@ -45,7 +45,7 @@ public class DeathEvent implements Listener {
             case BLOCK_EXPLOSION:
                 return new BlockExplosionBasePlayerDeathEventMessage(player);
             case ENTITY_EXPLOSION:
-                return new EntityExplosionBasePlayerDeathEventMessage(player);
+                return new EntityExplosionBasePlayerDeathEventMessage(player, killer);
             case VOID:
                 return new VoidBasePlayerDeathEventMessage(player);
             case SUICIDE:

--- a/src/main/java/space/yurisi/universecorev2/subplugins/changemessages/message/event/player_death/EntityExplosionBasePlayerDeathEventMessage.java
+++ b/src/main/java/space/yurisi/universecorev2/subplugins/changemessages/message/event/player_death/EntityExplosionBasePlayerDeathEventMessage.java
@@ -1,19 +1,72 @@
 package space.yurisi.universecorev2.subplugins.changemessages.message.event.player_death;
 
 import net.kyori.adventure.text.Component;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
+import org.bukkit.entity.Projectile;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.EntityDamageEvent;
 
 public class EntityExplosionBasePlayerDeathEventMessage extends BasePlayerDeathEventMessage{
 
-    public EntityExplosionBasePlayerDeathEventMessage(Player player){
-        super(player);
+    public EntityExplosionBasePlayerDeathEventMessage(Player player, Player killer) {
+        super(player, killer);
     }
 
     @Override
-    protected void init(Player player) {
+    protected void init(Player player, Player killer) {
+        if (killer == null) {
+            EntityDamageEvent cause = player.getLastDamageCause();
+            if (cause instanceof EntityDamageByEntityEvent e && e.getDamager() instanceof Projectile damager) {
+                if (damager.getShooter() instanceof Entity shooter) {
+                    String item = getItemName((Player) shooter);
+                    setMessages(
+                            new Component[]{
+                                    Component.text("§a§l[戦闘型AI] §c" + shooter.getName() + "§a が §b" + player.getName() + "§a を -§d" + item + "§a- で爆破しました"),
+                                    Component.text("§a§l[戦闘型AI] §c" + shooter.getName() + "§a が §b" + player.getName() + "§a を -§d" + item + "§a- で爆殺しました"),
+                                    Component.text("§a§l[戦闘型AI] §c" + shooter.getName() + "§a が §b" + player.getName() + "§a を -§d" + item + "§a- で絶命させた！"),
+                                    Component.text("§a§l[戦闘型AI] §c" + shooter.getName() + "§a が §b" + player.getName() + "§a を -§d" + item + "§a- で倒しました"),
+
+                            }
+                    );
+                } else {
+                    setMessages(
+                            new Component[]{
+                                    Component.text("§a§l[死亡管理AI] §c" + player.getName() + "§a が死亡した")
+                            }
+                    );
+                }
+                return;
+
+            }
+
+            setMessages(
+                    new Component[]{
+                            Component.text("")
+                    }
+            );
+            return;
+
+        }
+
+        if (player.getName().equals(killer.getName())) {
+            setMessages(
+                    new Component[]{
+                            Component.text("§a§l[死亡管理AI] §c" + player.getName() + "§a が 自分の放った矢で自爆した"),
+                            Component.text("§a§l[死亡管理AI] §c" + player.getName() + "§a が 自分の放った弾で自爆した")
+                    }
+            );
+            return;
+        }
+
+        String item = getItemName(killer);
+
         setMessages(
                 new Component[]{
-                        Component.text("")
+                        Component.text("§a§l[戦闘型AI] §c" + killer.getName() + "§a が §b" + player.getName() + "§a を -§d" + item + "§a- で爆殺しました"),
+                        Component.text("§a§l[戦闘型AI] §c" + killer.getName() + "§a が §b" + player.getName() + "§a を -§d" + item + "§a- でばらばらにしました"),
+                        Component.text("§a§l[戦闘型AI] §c" + killer.getName() + "§a が §b" + player.getName() + "§a を -§d" + item + "§a- の爆発によって生命活動が停止させた"),
+                        Component.text("§a§l[戦闘型AI] §c" + killer.getName() + "§a が §b" + player.getName() + "§a を -§d" + item + "§a- の爆発で骨にした"),
                 }
         );
     }

--- a/src/main/java/space/yurisi/universecorev2/subplugins/sitdown/event/EventListener.java
+++ b/src/main/java/space/yurisi/universecorev2/subplugins/sitdown/event/EventListener.java
@@ -53,6 +53,10 @@ public final class EventListener implements Listener {
             return;
         }
 
+        if (!player.getInventory().getItemInMainHand().getType().isAir()) {
+            return;
+        }
+
         if (!block.getType().toString().contains("STAIRS")) {
             return;
         }

--- a/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/command/GunCommand.java
+++ b/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/command/GunCommand.java
@@ -8,7 +8,6 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import space.yurisi.universecorev2.subplugins.universeguns.connector.UniverseCoreAPIConnector;
 import space.yurisi.universecorev2.subplugins.universeguns.menu.AmmoManagerInventoryMenu;
-import space.yurisi.universecorev2.utils.Message;
 
 public class GunCommand implements CommandExecutor {
 

--- a/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/connector/UniverseCoreAPIConnector.java
+++ b/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/connector/UniverseCoreAPIConnector.java
@@ -1,17 +1,12 @@
 package space.yurisi.universecorev2.subplugins.universeguns.connector;
 
-import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import space.yurisi.universecorev2.database.DatabaseManager;
-import space.yurisi.universecorev2.database.models.Ammo;
-import space.yurisi.universecorev2.database.models.User;
 import space.yurisi.universecorev2.database.repositories.AmmoRepository;
-import space.yurisi.universecorev2.database.repositories.MoneyRepository;
 import space.yurisi.universecorev2.database.repositories.UserRepository;
 import space.yurisi.universecorev2.exception.AmmoNotFoundException;
 import space.yurisi.universecorev2.exception.UserNotFoundException;
 import space.yurisi.universecorev2.subplugins.universeguns.constants.GunType;
-import space.yurisi.universecorev2.utils.Message;
 
 
 public class UniverseCoreAPIConnector {

--- a/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/constants/GunType.java
+++ b/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/constants/GunType.java
@@ -8,7 +8,9 @@ public enum GunType {
     SG(30),
     HG(40),
     LMG(50),
-    EX(60);
+    EX(60),
+    PRIMARY(70),
+    SECONDARY(71);
     
     
     private int id;

--- a/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/constants/GunType.java
+++ b/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/constants/GunType.java
@@ -4,6 +4,8 @@ public enum GunType {
 
     AR(1),
     SR(10),
+    SR_BOLT(11),
+    SR_SEMI(12),
     SMG(20),
     SG(30),
     HG(40),

--- a/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/core/EquipmentLimit.java
+++ b/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/core/EquipmentLimit.java
@@ -1,0 +1,79 @@
+package space.yurisi.universecorev2.subplugins.universeguns.core;
+
+import org.bukkit.NamespacedKey;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.potion.PotionEffectType;
+import space.yurisi.universecorev2.UniverseCoreV2;
+import space.yurisi.universecorev2.constants.UniverseItemKeyString;
+import space.yurisi.universecorev2.item.gun.Gun;
+import space.yurisi.universecorev2.subplugins.universeguns.constants.GunType;
+import space.yurisi.universecorev2.utils.Message;
+
+import java.util.Objects;
+
+public class EquipmentLimit {
+
+    private boolean[] checkEquipmentLimit(Player player){
+        int primaryLimit = 1;
+        int secondaryLimit = 1;
+        ItemStack chestplate = player.getInventory().getChestplate();
+        if(chestplate != null && chestplate.hasItemMeta()){
+            ItemMeta meta = chestplate.getItemMeta();
+            PersistentDataContainer container = meta.getPersistentDataContainer();
+            NamespacedKey itemKey = new NamespacedKey(UniverseCoreV2.getInstance(), UniverseItemKeyString.ITEM_NAME);
+            if(container.has(itemKey, PersistentDataType.STRING) && Objects.equals(container.get(itemKey, PersistentDataType.STRING), "tactical_vest")){
+                secondaryLimit = 2;
+            }
+        }
+        int[] hotbarCount = scanHotbar(player);
+        boolean[] result = new boolean[2];
+        // 超えてたらfalse
+        result[0] = hotbarCount[0] < primaryLimit;
+        result[1] = hotbarCount[1] < secondaryLimit;
+        return result;
+    }
+
+    private int[] scanHotbar(Player player){
+        int primaryCount = 0;
+        int secondaryCount = 0;
+
+        for (int i = 0; i < 9; i++) {
+            ItemStack item = player.getInventory().getItem(i);
+            if (item == null || !item.hasItemMeta()) {
+                continue;
+            }
+
+            Gun gun = Gun.getGun(item);
+            if (gun == null) {
+                continue;
+            }
+
+            if (gun.getEquipmentType() == GunType.PRIMARY) {
+                primaryCount++;
+            } else if (gun.getEquipmentType() == GunType.SECONDARY) {
+                secondaryCount++;
+            }
+        }
+
+        return new int[]{primaryCount, secondaryCount};
+    }
+
+    public boolean debuffEquipmentLimit(Player player){
+        boolean[] result = checkEquipmentLimit(player);
+        if(!result[0]){
+            Message.sendWarningMessage(player, "[武器AI]", "プライマリの所持制限を超えています。");
+        }
+        if(!result[1]){
+            Message.sendWarningMessage(player, "[武器AI]", "セカンダリの所持制限を超えています。");
+        }
+        if(!result[0] || !result[1]){
+            player.addPotionEffect(PotionEffectType.SLOWNESS.createEffect(1000000, 5));
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/core/EquipmentLimit.java
+++ b/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/core/EquipmentLimit.java
@@ -32,12 +32,12 @@ public class EquipmentLimit {
         int[] hotbarCount = scanHotbar(player);
         boolean[] result = new boolean[2];
         // 超えてたらfalse
-        result[0] = hotbarCount[0] < primaryLimit;
-        result[1] = hotbarCount[1] < secondaryLimit;
+        result[0] = hotbarCount[0] <= primaryLimit;
+        result[1] = hotbarCount[1] <= secondaryLimit;
         return result;
     }
 
-    private int[] scanHotbar(Player player){
+    public int[] scanHotbar(Player player){
         int primaryCount = 0;
         int secondaryCount = 0;
 
@@ -64,16 +64,27 @@ public class EquipmentLimit {
 
     public boolean debuffEquipmentLimit(Player player){
         boolean[] result = checkEquipmentLimit(player);
-        if(!result[0]){
-            Message.sendWarningMessage(player, "[武器AI]", "プライマリの所持制限を超えています。");
-        }
-        if(!result[1]){
-            Message.sendWarningMessage(player, "[武器AI]", "セカンダリの所持制限を超えています。");
-        }
         if(!result[0] || !result[1]){
-            player.addPotionEffect(PotionEffectType.SLOWNESS.createEffect(1000000, 5));
+            setEquipmentEffect(player, true);
+            if(!result[0]){
+                Message.sendWarningMessage(player, "[武器AI]", "プライマリの所持制限を超えています。");
+            }
+            if(!result[1]){
+                Message.sendWarningMessage(player, "[武器AI]", "セカンダリの所持制限を超えています。");
+            }
             return true;
         }
+        setEquipmentEffect(player, false);
         return false;
+    }
+
+    public void setEquipmentEffect(Player player, Boolean isOver){
+        if(isOver){
+            player.addPotionEffect(PotionEffectType.SLOWNESS.createEffect(1000000, 10));
+            player.addPotionEffect(PotionEffectType.BLINDNESS.createEffect(1000000, 10));
+        }else{
+            player.removePotionEffect(PotionEffectType.SLOWNESS);
+            player.removePotionEffect(PotionEffectType.BLINDNESS);
+        }
     }
 }

--- a/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/event/GunEvent.java
+++ b/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/event/GunEvent.java
@@ -41,7 +41,11 @@ import space.yurisi.universecorev2.subplugins.universeguns.manager.GunStatusMana
 import space.yurisi.universecorev2.subplugins.universeguns.menu.AmmoManagerInventoryMenu;
 import space.yurisi.universecorev2.utils.Message;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Objects;
+import java.util.Arrays;
 
 public class GunEvent implements Listener {
 

--- a/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/event/GunEvent.java
+++ b/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/event/GunEvent.java
@@ -608,10 +608,15 @@ public class GunEvent implements Listener {
                 ItemMeta meta = leggings.getItemMeta();
                 PersistentDataContainer container = meta.getPersistentDataContainer();
                 NamespacedKey itemKey = new NamespacedKey(UniverseCoreV2.getInstance(), UniverseItemKeyString.ITEM_NAME);
+                double reloadTimeCoefficient = 1.0;
                 if (container.has(itemKey, PersistentDataType.STRING) &&  Objects.equals(container.get(itemKey, PersistentDataType.STRING), "tactical_leggings")) {
-                    double newReloadTime = reloadTime * 0.7;
-                    reloadTime = (int) newReloadTime;
+                    reloadTimeCoefficient -= 0.3;
                 }
+                if (container.has(itemKey, PersistentDataType.STRING) &&  Objects.equals(container.get(itemKey, PersistentDataType.STRING), "tactical_vest")) {
+                    reloadTimeCoefficient -= 0.1;
+                }
+                double newReloadTime = reloadTime * reloadTimeCoefficient;
+                reloadTime = (int) newReloadTime;
             }
 
             boolean result = gunStatus.startReload(reloadTime, player);
@@ -779,6 +784,15 @@ public class GunEvent implements Listener {
     private boolean[] checkEquipmentLimit(Player player){
         int primaryLimit = 1;
         int secondaryLimit = 1;
+        ItemStack chestplate = player.getInventory().getChestplate();
+        if(chestplate != null && chestplate.hasItemMeta()){
+            ItemMeta meta = chestplate.getItemMeta();
+            PersistentDataContainer container = meta.getPersistentDataContainer();
+            NamespacedKey itemKey = new NamespacedKey(UniverseCoreV2.getInstance(), UniverseItemKeyString.ITEM_NAME);
+            if(container.has(itemKey, PersistentDataType.STRING) && Objects.equals(container.get(itemKey, PersistentDataType.STRING), "tactical_vest")){
+                secondaryLimit = 2;
+            }
+        }
         int[] hotbarCount = scanHotbar(player);
         boolean[] result = new boolean[2];
         // 超えてたらfalse

--- a/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/event/GunEvent.java
+++ b/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/event/GunEvent.java
@@ -92,18 +92,12 @@ public class GunEvent implements Listener {
             return;
         }
 
-        if (!Gun.isGun(itemInHand)) {
+        Gun gun = Gun.getGun(itemInHand);
+        if(gun == null){
             return;
         }
 
-        String handItemID = container.get(itemKey, PersistentDataType.STRING);
         String gunSerial = container.get(gunSerialKey, PersistentDataType.STRING);
-
-        CustomItem gunItem = UniverseItem.getItem(handItemID);
-
-        if (!(gunItem instanceof Gun gun)) {
-            return;
-        }
 
         if (!GunStatusManager.isExists(gunSerial)) {
             GunStatusManager.register(gunSerial, gun, connector);
@@ -416,7 +410,8 @@ public class GunEvent implements Listener {
             NamespacedKey newItemKey = new NamespacedKey(UniverseCoreV2.getInstance(), UniverseItemKeyString.ITEM_NAME);
             NamespacedKey gunSerialKey = new NamespacedKey(UniverseCoreV2.getInstance(), UniverseItemKeyString.GUN_SERIAL);
 
-            if (!Gun.isGun(newInHand)) {
+            Gun gun = Gun.getGun(newInHand);
+            if (gun == null) {
                 player.setWalkSpeed(0.2f);
                 return;
             }
@@ -462,19 +457,13 @@ public class GunEvent implements Listener {
     private void cancelOldGun(ItemStack oldInHand, Player player) {
         ItemMeta oldMeta = oldInHand.getItemMeta();
         PersistentDataContainer oldContainer = oldMeta.getPersistentDataContainer();
-        NamespacedKey oldItemKey = new NamespacedKey(UniverseCoreV2.getInstance(), UniverseItemKeyString.ITEM_NAME);
         NamespacedKey gunSerialKey = new NamespacedKey(UniverseCoreV2.getInstance(), UniverseItemKeyString.GUN_SERIAL);
-        if (!Gun.isGun(oldInHand)) {
+        Gun oldGun = Gun.getGun(oldInHand);
+        if (oldGun == null) {
             return;
         }
 
-        String oldHandItemID = oldContainer.get(oldItemKey, PersistentDataType.STRING);
         String oldGunSerial = oldContainer.get(gunSerialKey, PersistentDataType.STRING);
-        CustomItem oldGunItem = UniverseItem.getItem(oldHandItemID);
-
-        if (!(oldGunItem instanceof Gun oldGun)) {
-            return;
-        }
 
         if(!connector.isExistsAmmoData(player)){
             try {
@@ -506,23 +495,14 @@ public class GunEvent implements Listener {
     public void onPlayerSwapHandItems(PlayerSwapHandItemsEvent event) {
         ItemStack offHandItem = event.getOffHandItem();
         if (offHandItem.hasItemMeta()) {
-            ItemMeta meta = offHandItem.getItemMeta();
-            PersistentDataContainer container = meta.getPersistentDataContainer();
-            NamespacedKey itemKey = new NamespacedKey(UniverseCoreV2.getInstance(), UniverseItemKeyString.ITEM_NAME);
-            NamespacedKey gunKey = new NamespacedKey(UniverseCoreV2.getInstance(), UniverseItemKeyString.GUN);
 
-            if (!Gun.isGun(offHandItem)) {
-                return;
-            }
-            String handItemID = container.get(itemKey, PersistentDataType.STRING);
-            CustomItem gunItem = UniverseItem.getItem(handItemID);
-            if (!(gunItem instanceof Gun)) {
+            Gun gun = Gun.getGun(offHandItem);
+            if (gun == null) {
                 return;
             }
 
             event.setCancelled(true);
             Message.sendWarningMessage(event.getPlayer(), "[武器AI]", "オフハンドに武器を持つことはできません。");
-
         }
     }
 
@@ -567,23 +547,12 @@ public class GunEvent implements Listener {
         }
 
         ItemStack itemInHand = player.getInventory().getItemInMainHand();
-        ItemMeta meta = itemInHand.getItemMeta();
         if (!itemInHand.hasItemMeta()) {
             return;
         }
-        PersistentDataContainer container = meta.getPersistentDataContainer();
 
-        NamespacedKey itemKey = new NamespacedKey(UniverseCoreV2.getInstance(), UniverseItemKeyString.ITEM_NAME);
-        NamespacedKey gunKey = new NamespacedKey(UniverseCoreV2.getInstance(), UniverseItemKeyString.GUN);
-
-        if (!Gun.isGun(itemInHand)) {
-            return;
-        }
-
-        String handItemID = container.get(itemKey, PersistentDataType.STRING);
-        CustomItem gunItem = UniverseItem.getItem(handItemID);
-
-        if (!(gunItem instanceof Gun gun)) {
+        Gun gun = Gun.getGun(itemInHand);
+        if (gun == null) {
             return;
         }
 
@@ -679,7 +648,8 @@ public class GunEvent implements Listener {
             if (item == null || !item.hasItemMeta()) {
                 return;
             }
-            if(!Gun.isGun(item)){
+            Gun gun = Gun.getGun(item);
+            if(gun == null){
                 return;
             }
 
@@ -707,19 +677,10 @@ public class GunEvent implements Listener {
                 return;
             }
 
-            ItemMeta meta = item.getItemMeta();
-            PersistentDataContainer container = meta.getPersistentDataContainer();
-            NamespacedKey itemKey = new NamespacedKey(UniverseCoreV2.getInstance(), UniverseItemKeyString.ITEM_NAME);
-            String clickedItemID = container.get(itemKey, PersistentDataType.STRING);
-            CustomItem clickedGunItem = UniverseItem.getItem(clickedItemID);
-            if(!(clickedGunItem instanceof Gun clickedGun)){
-                return;
-            }
-
-            if(clickedGun.getEquipmentType() == GunType.PRIMARY && !result[0]){
+            if(gun.getEquipmentType() == GunType.PRIMARY && !result[0]){
                 Message.sendWarningMessage(player, "[武器AI]", "プライマリの所持制限を超えています。");
                 event.setCancelled(true);
-            }else if(clickedGun.getEquipmentType() == GunType.SECONDARY && !result[1]){
+            }else if(gun.getEquipmentType() == GunType.SECONDARY && !result[1]){
                 Message.sendWarningMessage(player, "[武器AI]", "セカンダリの所持制限を超えています。");
                 event.setCancelled(true);
             }
@@ -736,18 +697,8 @@ public class GunEvent implements Listener {
         if (!item.hasItemMeta()) {
             return;
         }
-        if (!Gun.isGun(item)) {
-            return;
-        }
-
-        ItemMeta meta = item.getItemMeta();
-        PersistentDataContainer container = meta.getPersistentDataContainer();
-        NamespacedKey itemKey = new NamespacedKey(UniverseCoreV2.getInstance(), UniverseItemKeyString.ITEM_NAME);
-
-        String handItemID = container.get(itemKey, PersistentDataType.STRING);
-        CustomItem gunItem = UniverseItem.getItem(handItemID);
-
-        if (!(gunItem instanceof Gun gun)) {
+        Gun gun = Gun.getGun(item);
+        if (gun == null) {
             return;
         }
 
@@ -808,24 +759,14 @@ public class GunEvent implements Listener {
     private int[] scanHotbar(Player player){
         int primaryCount = 0;
         int secondaryCount = 0;
-        NamespacedKey itemKey = new NamespacedKey(UniverseCoreV2.getInstance(), UniverseItemKeyString.ITEM_NAME);
 
         for (ItemStack item : player.getInventory().getContents()) {
             if (item == null || !item.hasItemMeta()) {
                 continue;
             }
 
-            ItemMeta meta = item.getItemMeta();
-            PersistentDataContainer container = meta.getPersistentDataContainer();
-
-            if (!Gun.isGun(item)) {
-                continue;
-            }
-
-            String handItemID = container.get(itemKey, PersistentDataType.STRING);
-            CustomItem gunItem = UniverseItem.getItem(handItemID);
-
-            if (!(gunItem instanceof Gun gun)) {
+            Gun gun = Gun.getGun(item);
+            if (gun == null) {
                 continue;
             }
 
@@ -848,17 +789,10 @@ public class GunEvent implements Listener {
             return;
         }
         PersistentDataContainer container = meta.getPersistentDataContainer();
-        NamespacedKey itemKey = new NamespacedKey(UniverseCoreV2.getInstance(), UniverseItemKeyString.ITEM_NAME);
         NamespacedKey gunSerialKey = new NamespacedKey(UniverseCoreV2.getInstance(), UniverseItemKeyString.GUN_SERIAL);
 
-        if (!Gun.isGun(droppedItem)) {
-            return;
-        }
-
-        String handItemID = container.get(itemKey, PersistentDataType.STRING);
-        CustomItem gunItem = UniverseItem.getItem(handItemID);
-
-        if (!(gunItem instanceof Gun gun)) {
+        Gun gun = Gun.getGun(droppedItem);
+        if (gun == null) {
             return;
         }
 

--- a/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/event/GunEvent.java
+++ b/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/event/GunEvent.java
@@ -264,7 +264,7 @@ public class GunEvent implements Listener {
                 isHandlingExplosion.set(true);
                 try {
                     snowball.getWorld().createExplosion(loc, radius, false, false, snowball);
-                    snowball.getWorld().spawnParticle(Particle.EXPLOSION, loc, 1);
+                    snowball.getWorld().spawnParticle(Particle.EXPLOSION_EMITTER, loc, 1);
                 } finally {
                     isHandlingExplosion.set(false);
                 }
@@ -339,7 +339,7 @@ public class GunEvent implements Listener {
             try {
                 snowball.getWorld().createExplosion(loc, radius, false, false, snowball);
 
-                snowball.getWorld().spawnParticle(Particle.EXPLOSION, loc, 1);
+                snowball.getWorld().spawnParticle(Particle.EXPLOSION_EMITTER, loc, 1);
             } finally {
                 isHandlingExplosion.set(false);
             }
@@ -583,10 +583,10 @@ public class GunEvent implements Listener {
                 NamespacedKey itemKey = new NamespacedKey(UniverseCoreV2.getInstance(), UniverseItemKeyString.ITEM_NAME);
                 double reloadTimeCoefficient = 1.0;
                 if (container.has(itemKey, PersistentDataType.STRING) &&  Objects.equals(container.get(itemKey, PersistentDataType.STRING), "tactical_leggings")) {
-                    reloadTimeCoefficient -= 0.3;
+                    reloadTimeCoefficient -= 0.2;
                 }
                 if (container.has(itemKey, PersistentDataType.STRING) &&  Objects.equals(container.get(itemKey, PersistentDataType.STRING), "tactical_vest")) {
-                    reloadTimeCoefficient -= 0.1;
+                    reloadTimeCoefficient -= 0.3;
                 }
                 double newReloadTime = reloadTime * reloadTimeCoefficient;
                 reloadTime = (int) newReloadTime;
@@ -641,144 +641,181 @@ public class GunEvent implements Listener {
 
     }
 
-    @EventHandler
-    public void onInventoryClick(InventoryClickEvent event) {
-        if (event.getWhoClicked() instanceof Player player) {
-            ItemStack item = event.getCurrentItem();
-            if (item == null || !item.hasItemMeta()) {
-                return;
-            }
-            Gun gun = Gun.getGun(item);
-            if(gun == null){
-                return;
-            }
-
-            if (reloadingTasks.containsKey(player)) {
-                event.setCancelled(true);
-                return;
-            }
-
-            int destinationSlot = event.getRawSlot();
-            if(destinationSlot == 40){
-                // オフハンド
-                Message.sendWarningMessage(player, "[武器AI]", "オフハンドに武器を持つことはできません。");
-                event.setCancelled(true);
-                return;
-            }
-
-            if(destinationSlot > 8) {
-                return;
-            }
-
-            boolean[] result = checkEquipmentLimit(player);
-            if(!result[0] && !result[1]){
-                Message.sendWarningMessage(player, "[武器AI]", "これ以上武器を持つことはできません。");
-                event.setCancelled(true);
-                return;
-            }
-
-            if(gun.getEquipmentType() == GunType.PRIMARY && !result[0]){
-                Message.sendWarningMessage(player, "[武器AI]", "プライマリの所持制限を超えています。");
-                event.setCancelled(true);
-            }else if(gun.getEquipmentType() == GunType.SECONDARY && !result[1]){
-                Message.sendWarningMessage(player, "[武器AI]", "セカンダリの所持制限を超えています。");
-                event.setCancelled(true);
-            }
-        }
-    }
-
-
-    @EventHandler(priority = EventPriority.LOW)
-    public void onPlayerPickupItem(EntityPickupItemEvent event) {
-        if (!(event.getEntity() instanceof Player player)) {
-            return;
-        }
-        ItemStack item = event.getItem().getItemStack();
-        if (!item.hasItemMeta()) {
-            return;
-        }
-        Gun gun = Gun.getGun(item);
-        if (gun == null) {
-            return;
-        }
-
-        boolean[] result = checkEquipmentLimit(player);
-        if(result[0] && result[1]){
-            return;
-        }
-        int emptySlot = -1;
-        ItemStack[] contents = player.getInventory().getContents();
-        boolean isHotbarFull = Arrays.stream(contents, 0, 9).allMatch(Objects::isNull);
-        if (isHotbarFull) {
-            return;
-        }
-
-        for (int i = 9; i < contents.length; i++) {
-            if (contents[i] == null) {
-                emptySlot = i;
-                break;
-            }
-        }
-        if(emptySlot == -1){
-            if(!result[0] && gun.getEquipmentType() == GunType.PRIMARY) {
-                Message.sendWarningMessage(player, "[武器AI]", "プライマリの所持制限を超えています。");
-                event.setCancelled(true);
-            }else if(!result[1] && gun.getEquipmentType() == GunType.SECONDARY){
-                Message.sendWarningMessage(player, "[武器AI]", "セカンダリの所持制限を超えています。");
-                event.setCancelled(true);
-            }
-        } else {
-            if((!result[0] && gun.getEquipmentType() == GunType.PRIMARY) || (!result[1] && gun.getEquipmentType() == GunType.SECONDARY)) {
-                player.getInventory().setItem(emptySlot, item);
-                event.getItem().remove();
-                event.setCancelled(true);
-            }
-        }
-    }
-
-    private boolean[] checkEquipmentLimit(Player player){
-        int primaryLimit = 1;
-        int secondaryLimit = 1;
-        ItemStack chestplate = player.getInventory().getChestplate();
-        if(chestplate != null && chestplate.hasItemMeta()){
-            ItemMeta meta = chestplate.getItemMeta();
-            PersistentDataContainer container = meta.getPersistentDataContainer();
-            NamespacedKey itemKey = new NamespacedKey(UniverseCoreV2.getInstance(), UniverseItemKeyString.ITEM_NAME);
-            if(container.has(itemKey, PersistentDataType.STRING) && Objects.equals(container.get(itemKey, PersistentDataType.STRING), "tactical_vest")){
-                secondaryLimit = 2;
-            }
-        }
-        int[] hotbarCount = scanHotbar(player);
-        boolean[] result = new boolean[2];
-        // 超えてたらfalse
-        result[0] = hotbarCount[0] < primaryLimit;
-        result[1] = hotbarCount[1] < secondaryLimit;
-        return result;
-    }
-
-    private int[] scanHotbar(Player player){
-        int primaryCount = 0;
-        int secondaryCount = 0;
-
-        for (ItemStack item : player.getInventory().getContents()) {
-            if (item == null || !item.hasItemMeta()) {
-                continue;
-            }
-
-            Gun gun = Gun.getGun(item);
-            if (gun == null) {
-                continue;
-            }
-
-            if (gun.getEquipmentType() == GunType.PRIMARY) {
-                primaryCount++;
-            } else if (gun.getEquipmentType() == GunType.SECONDARY) {
-                secondaryCount++;
-            }
-        }
-
-        return new int[]{primaryCount, secondaryCount};
-    }
+//    @EventHandler
+//    public void onInventoryClick(InventoryClickEvent event) {
+//        if (event.getWhoClicked() instanceof Player player) {
+//            player.sendMessage("called");
+//            int destinationSlot = event.getRawSlot();
+//            int slot = event.getSlot();
+//            ItemStack item = event.getCurrentItem();
+//            if(item != null && item.hasItemMeta()){
+//                Gun newGun = Gun.getGun(item);
+//                if(newGun != null){
+//                    player.getInventory().setItem(slot, null);
+//                    return;
+//                }
+//            }
+//
+//            ItemStack oldItem = event.getCursor();
+//            if (!oldItem.hasItemMeta()) {
+//                return;
+//            }
+//            Gun gun = Gun.getGun(oldItem);
+//            if(gun == null){
+//                return;
+//            }
+//
+//            if (reloadingTasks.containsKey(player)) {
+//                event.setCancelled(true);
+//                return;
+//            }
+//
+//            if(destinationSlot == 45){
+//                // オフハンド
+//                Message.sendWarningMessage(player, "[武器AI]", "オフハンドに武器を持つことはできません。");
+//                event.setCancelled(true);
+//                putGunToEmptySlot(player, oldItem);
+//                return;
+//            }
+//            if(destinationSlot <= 35) {
+//                return;
+//            }
+//
+//            boolean[] result = checkEquipmentLimit(player);
+//            if(!result[0] && !result[1]){
+//                event.setCancelled(true);
+//                Message.sendWarningMessage(player, "[武器AI]", "これ以上武器を持つことはできません。");
+//                putGunToEmptySlot(player, oldItem);
+//
+//                return;
+//            }
+//
+//            if(gun.getEquipmentType() == GunType.PRIMARY && !result[0]){
+//                event.setCancelled(true);
+//                Message.sendWarningMessage(player, "[武器AI]", "プライマリの所持制限を超えています。");
+//                putGunToEmptySlot(player, oldItem);
+//            }else if(gun.getEquipmentType() == GunType.SECONDARY && !result[1]){
+//                event.setCancelled(true);
+//                Message.sendWarningMessage(player, "[武器AI]", "セカンダリの所持制限を超えています。");
+//                putGunToEmptySlot(player, oldItem);
+//            }
+//            player.updateInventory();
+//        }
+//    }
+//
+//    private void putGunToEmptySlot(Player player, ItemStack item){
+//        ItemStack[] contents = player.getInventory().getContents();
+//        int emptySlot = -1;
+//
+//        for (int i = 9; i < 36; i++) {
+//            if (contents[i] == null) {
+//                emptySlot = i;
+//                break;
+//            }else{
+//                player.sendMessage(contents[i].toString());
+//            }
+//        }
+//        if(emptySlot == -1){
+//            player.getWorld().dropItemNaturally(player.getLocation(), item);
+//            return;
+//        }
+//        player.getInventory().setItem(emptySlot, item);
+//    }
+//
+//
+//    @EventHandler(priority = EventPriority.LOW)
+//    public void onPlayerPickupItem(EntityPickupItemEvent event) {
+//        if (!(event.getEntity() instanceof Player player)) {
+//            return;
+//        }
+//        ItemStack item = event.getItem().getItemStack();
+//        if (!item.hasItemMeta()) {
+//            return;
+//        }
+//        Gun gun = Gun.getGun(item);
+//        if (gun == null) {
+//            return;
+//        }
+//
+//        boolean[] result = checkEquipmentLimit(player);
+//        if(result[0] && result[1]){
+//            return;
+//        }
+//        int emptySlot = -1;
+//        ItemStack[] contents = player.getInventory().getContents();
+//        boolean isHotbarFull = Arrays.stream(contents, 0, 9).allMatch(Objects::isNull);
+//        if (isHotbarFull) {
+//            return;
+//        }
+//
+//        for (int i = 9; i < 36; i++) {
+//            if (contents[i] == null) {
+//                emptySlot = i;
+//                break;
+//            }
+//        }
+//        if(emptySlot == -1){
+//            if(!result[0] && gun.getEquipmentType() == GunType.PRIMARY) {
+//                Message.sendWarningMessage(player, "[武器AI]", "プライマリの所持制限を超えています。");
+//                event.setCancelled(true);
+//            }else if(!result[1] && gun.getEquipmentType() == GunType.SECONDARY){
+//                Message.sendWarningMessage(player, "[武器AI]", "セカンダリの所持制限を超えています。");
+//                event.setCancelled(true);
+//            }
+//        } else {
+//            if((!result[0] && gun.getEquipmentType() == GunType.PRIMARY) || (!result[1] && gun.getEquipmentType() == GunType.SECONDARY)) {
+//                player.getInventory().setItem(emptySlot, item);
+//                event.getItem().remove();
+//                event.setCancelled(true);
+//                player.playSound(player.getLocation(), Sound.ENTITY_ITEM_PICKUP, 1.0F, 1.0F);
+//            }
+//        }
+//    }
+//
+//    private boolean[] checkEquipmentLimit(Player player){
+//        int primaryLimit = 1;
+//        int secondaryLimit = 1;
+//        ItemStack chestplate = player.getInventory().getChestplate();
+//        if(chestplate != null && chestplate.hasItemMeta()){
+//            ItemMeta meta = chestplate.getItemMeta();
+//            PersistentDataContainer container = meta.getPersistentDataContainer();
+//            NamespacedKey itemKey = new NamespacedKey(UniverseCoreV2.getInstance(), UniverseItemKeyString.ITEM_NAME);
+//            if(container.has(itemKey, PersistentDataType.STRING) && Objects.equals(container.get(itemKey, PersistentDataType.STRING), "tactical_vest")){
+//                secondaryLimit = 2;
+//            }
+//        }
+//        int[] hotbarCount = scanHotbar(player);
+//        boolean[] result = new boolean[2];
+//        // 超えてたらfalse
+//        result[0] = hotbarCount[0] < primaryLimit;
+//        result[1] = hotbarCount[1] < secondaryLimit;
+//        return result;
+//    }
+//
+//    private int[] scanHotbar(Player player){
+//        int primaryCount = 0;
+//        int secondaryCount = 0;
+//
+//        for (int i = 0; i < 9; i++) {
+//            ItemStack item = player.getInventory().getItem(i);
+//            if (item == null || !item.hasItemMeta()) {
+//                continue;
+//            }
+//
+//            Gun gun = Gun.getGun(item);
+//            if (gun == null) {
+//                continue;
+//            }
+//
+//            if (gun.getEquipmentType() == GunType.PRIMARY) {
+//                primaryCount++;
+//            } else if (gun.getEquipmentType() == GunType.SECONDARY) {
+//                secondaryCount++;
+//            }
+//        }
+//
+//        return new int[]{primaryCount, secondaryCount};
+//    }
 
     @EventHandler
     public void onPlayerDropItem(PlayerDropItemEvent event) {

--- a/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/event/GunEvent.java
+++ b/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/event/GunEvent.java
@@ -34,6 +34,7 @@ import space.yurisi.universecorev2.subplugins.universeguns.connector.UniverseCor
 import space.yurisi.universecorev2.subplugins.universeguns.constants.GunType;
 import space.yurisi.universecorev2.subplugins.universeguns.core.BulletData;
 import space.yurisi.universecorev2.subplugins.universeguns.core.DamageCalculator;
+import space.yurisi.universecorev2.subplugins.universeguns.core.EquipmentLimit;
 import space.yurisi.universecorev2.subplugins.universeguns.core.GunStatus;
 import space.yurisi.universecorev2.subplugins.universeguns.manager.GunStatusManager;
 import space.yurisi.universecorev2.subplugins.universeguns.menu.AmmoManagerInventoryMenu;
@@ -91,6 +92,10 @@ public class GunEvent implements Listener {
 
         Gun gun = Gun.getGun(itemInHand);
         if(gun == null){
+            return;
+        }
+
+        if(new EquipmentLimit().debuffEquipmentLimit(player)){
             return;
         }
 
@@ -153,7 +158,7 @@ public class GunEvent implements Listener {
                                 }
                             }
 
-                        } else if (gun.getType().equals(GunType.SR)) {
+                        } else if (gun.getType().equals(GunType.SR_BOLT) || gun.getType().equals(GunType.SR_SEMI) || gun.getType().equals(GunType.SR)) {
                             if (!isZoom.contains(player)) {
                                 Message.sendWarningMessage(player, "[武器AI]", "狙撃時のみ発射できます。");
                                 return;
@@ -161,7 +166,7 @@ public class GunEvent implements Listener {
 
                             gunStatus.shoot();
                             new SniperShot(player, gun, gunStatus);
-                            if (Objects.equals(gun.getName(), "L96A1")) {
+                            if (gun.getType().equals(GunType.SR_BOLT)) {
                                 new BukkitRunnable() {
                                     @Override
                                     public void run() {
@@ -184,7 +189,7 @@ public class GunEvent implements Listener {
                             new BukkitRunnable() {
                                 @Override
                                 public void run() {
-                                    if (Objects.equals(gun.getName(), "L96A1")) {
+                                    if (gun.getType().equals(GunType.SR_BOLT)) {
                                         player.playSound(player.getLocation(), Sound.BLOCK_COPPER_DOOR_CLOSE, 1.0F, 0.6F);
                                     }
                                 }
@@ -412,6 +417,7 @@ public class GunEvent implements Listener {
                 player.setWalkSpeed(0.2f);
                 return;
             }
+            new EquipmentLimit().debuffEquipmentLimit(player);
 
             if(!connector.isExistsAmmoData(player)){
                 try {
@@ -644,182 +650,6 @@ public class GunEvent implements Listener {
         }
 
     }
-
-//    @EventHandler
-//    public void onInventoryClick(InventoryClickEvent event) {
-//        if (event.getWhoClicked() instanceof Player player) {
-//            player.sendMessage("called");
-//            int destinationSlot = event.getRawSlot();
-//            int slot = event.getSlot();
-//            ItemStack item = event.getCurrentItem();
-//            if(item != null && item.hasItemMeta()){
-//                Gun newGun = Gun.getGun(item);
-//                if(newGun != null){
-//                    player.getInventory().setItem(slot, null);
-//                    return;
-//                }
-//            }
-//
-//            ItemStack oldItem = event.getCursor();
-//            if (!oldItem.hasItemMeta()) {
-//                return;
-//            }
-//            Gun gun = Gun.getGun(oldItem);
-//            if(gun == null){
-//                return;
-//            }
-//
-//            if (reloadingTasks.containsKey(player)) {
-//                event.setCancelled(true);
-//                return;
-//            }
-//
-//            if(destinationSlot == 45){
-//                // オフハンド
-//                Message.sendWarningMessage(player, "[武器AI]", "オフハンドに武器を持つことはできません。");
-//                event.setCancelled(true);
-//                putGunToEmptySlot(player, oldItem);
-//                return;
-//            }
-//            if(destinationSlot <= 35) {
-//                return;
-//            }
-//
-//            boolean[] result = checkEquipmentLimit(player);
-//            if(!result[0] && !result[1]){
-//                event.setCancelled(true);
-//                Message.sendWarningMessage(player, "[武器AI]", "これ以上武器を持つことはできません。");
-//                putGunToEmptySlot(player, oldItem);
-//
-//                return;
-//            }
-//
-//            if(gun.getEquipmentType() == GunType.PRIMARY && !result[0]){
-//                event.setCancelled(true);
-//                Message.sendWarningMessage(player, "[武器AI]", "プライマリの所持制限を超えています。");
-//                putGunToEmptySlot(player, oldItem);
-//            }else if(gun.getEquipmentType() == GunType.SECONDARY && !result[1]){
-//                event.setCancelled(true);
-//                Message.sendWarningMessage(player, "[武器AI]", "セカンダリの所持制限を超えています。");
-//                putGunToEmptySlot(player, oldItem);
-//            }
-//            player.updateInventory();
-//        }
-//    }
-//
-//    private void putGunToEmptySlot(Player player, ItemStack item){
-//        ItemStack[] contents = player.getInventory().getContents();
-//        int emptySlot = -1;
-//
-//        for (int i = 9; i < 36; i++) {
-//            if (contents[i] == null) {
-//                emptySlot = i;
-//                break;
-//            }else{
-//                player.sendMessage(contents[i].toString());
-//            }
-//        }
-//        if(emptySlot == -1){
-//            player.getWorld().dropItemNaturally(player.getLocation(), item);
-//            return;
-//        }
-//        player.getInventory().setItem(emptySlot, item);
-//    }
-//
-//
-//    @EventHandler(priority = EventPriority.LOW)
-//    public void onPlayerPickupItem(EntityPickupItemEvent event) {
-//        if (!(event.getEntity() instanceof Player player)) {
-//            return;
-//        }
-//        ItemStack item = event.getItem().getItemStack();
-//        if (!item.hasItemMeta()) {
-//            return;
-//        }
-//        Gun gun = Gun.getGun(item);
-//        if (gun == null) {
-//            return;
-//        }
-//
-//        boolean[] result = checkEquipmentLimit(player);
-//        if(result[0] && result[1]){
-//            return;
-//        }
-//        int emptySlot = -1;
-//        ItemStack[] contents = player.getInventory().getContents();
-//        boolean isHotbarFull = Arrays.stream(contents, 0, 9).allMatch(Objects::isNull);
-//        if (isHotbarFull) {
-//            return;
-//        }
-//
-//        for (int i = 9; i < 36; i++) {
-//            if (contents[i] == null) {
-//                emptySlot = i;
-//                break;
-//            }
-//        }
-//        if(emptySlot == -1){
-//            if(!result[0] && gun.getEquipmentType() == GunType.PRIMARY) {
-//                Message.sendWarningMessage(player, "[武器AI]", "プライマリの所持制限を超えています。");
-//                event.setCancelled(true);
-//            }else if(!result[1] && gun.getEquipmentType() == GunType.SECONDARY){
-//                Message.sendWarningMessage(player, "[武器AI]", "セカンダリの所持制限を超えています。");
-//                event.setCancelled(true);
-//            }
-//        } else {
-//            if((!result[0] && gun.getEquipmentType() == GunType.PRIMARY) || (!result[1] && gun.getEquipmentType() == GunType.SECONDARY)) {
-//                player.getInventory().setItem(emptySlot, item);
-//                event.getItem().remove();
-//                event.setCancelled(true);
-//                player.playSound(player.getLocation(), Sound.ENTITY_ITEM_PICKUP, 1.0F, 1.0F);
-//            }
-//        }
-//    }
-//
-//    private boolean[] checkEquipmentLimit(Player player){
-//        int primaryLimit = 1;
-//        int secondaryLimit = 1;
-//        ItemStack chestplate = player.getInventory().getChestplate();
-//        if(chestplate != null && chestplate.hasItemMeta()){
-//            ItemMeta meta = chestplate.getItemMeta();
-//            PersistentDataContainer container = meta.getPersistentDataContainer();
-//            NamespacedKey itemKey = new NamespacedKey(UniverseCoreV2.getInstance(), UniverseItemKeyString.ITEM_NAME);
-//            if(container.has(itemKey, PersistentDataType.STRING) && Objects.equals(container.get(itemKey, PersistentDataType.STRING), "tactical_vest")){
-//                secondaryLimit = 2;
-//            }
-//        }
-//        int[] hotbarCount = scanHotbar(player);
-//        boolean[] result = new boolean[2];
-//        // 超えてたらfalse
-//        result[0] = hotbarCount[0] < primaryLimit;
-//        result[1] = hotbarCount[1] < secondaryLimit;
-//        return result;
-//    }
-//
-//    private int[] scanHotbar(Player player){
-//        int primaryCount = 0;
-//        int secondaryCount = 0;
-//
-//        for (int i = 0; i < 9; i++) {
-//            ItemStack item = player.getInventory().getItem(i);
-//            if (item == null || !item.hasItemMeta()) {
-//                continue;
-//            }
-//
-//            Gun gun = Gun.getGun(item);
-//            if (gun == null) {
-//                continue;
-//            }
-//
-//            if (gun.getEquipmentType() == GunType.PRIMARY) {
-//                primaryCount++;
-//            } else if (gun.getEquipmentType() == GunType.SECONDARY) {
-//                secondaryCount++;
-//            }
-//        }
-//
-//        return new int[]{primaryCount, secondaryCount};
-//    }
 
     @EventHandler
     public void onPlayerDropItem(PlayerDropItemEvent event) {

--- a/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/event/GunEvent.java
+++ b/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/event/GunEvent.java
@@ -11,9 +11,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.entity.EntityDamageByBlockEvent;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
-import org.bukkit.event.entity.EntityPickupItemEvent;
 import org.bukkit.event.entity.ProjectileHitEvent;
-import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.PrepareItemCraftEvent;
 import org.bukkit.event.player.*;
 import org.bukkit.inventory.CraftingInventory;
@@ -45,7 +43,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Objects;
-import java.util.Arrays;
 
 public class GunEvent implements Listener {
 
@@ -576,21 +573,28 @@ public class GunEvent implements Listener {
         }
         try {
             int reloadTime = gun.getReloadTime();
+            double reloadTimeCoefficient = 1.0;
             ItemStack leggings = player.getInventory().getLeggings();
             if (leggings != null && leggings.hasItemMeta()) {
-                ItemMeta meta = leggings.getItemMeta();
-                PersistentDataContainer container = meta.getPersistentDataContainer();
+                ItemMeta leggingsMeta = leggings.getItemMeta();
+                PersistentDataContainer container = leggingsMeta.getPersistentDataContainer();
                 NamespacedKey itemKey = new NamespacedKey(UniverseCoreV2.getInstance(), UniverseItemKeyString.ITEM_NAME);
-                double reloadTimeCoefficient = 1.0;
                 if (container.has(itemKey, PersistentDataType.STRING) &&  Objects.equals(container.get(itemKey, PersistentDataType.STRING), "tactical_leggings")) {
                     reloadTimeCoefficient -= 0.2;
                 }
+            }
+            ItemStack chestplate = player.getInventory().getChestplate();
+            if (chestplate != null && chestplate.hasItemMeta()) {
+                ItemMeta chestplateMeta = chestplate.getItemMeta();
+                PersistentDataContainer container = chestplateMeta.getPersistentDataContainer();
+                NamespacedKey itemKey = new NamespacedKey(UniverseCoreV2.getInstance(), UniverseItemKeyString.ITEM_NAME);
                 if (container.has(itemKey, PersistentDataType.STRING) &&  Objects.equals(container.get(itemKey, PersistentDataType.STRING), "tactical_vest")) {
                     reloadTimeCoefficient -= 0.3;
                 }
-                double newReloadTime = reloadTime * reloadTimeCoefficient;
-                reloadTime = (int) newReloadTime;
             }
+
+            double newReloadTime = reloadTime * reloadTimeCoefficient;
+            reloadTime = (int) newReloadTime;
 
             boolean result = gunStatus.startReload(reloadTime, player);
             if (!result) {


### PR DESCRIPTION
**武器の所持制限追加**
武器をプライマリとセカンダリの二種類に分類，説明欄に出るように
それぞれの所持制限数を超えてホットバーに入れていると暗闇と移動速度低下のデバフが入る
デフォルトの制限数は1,1

**タクティカルベストの実装**
リロード速度上昇(30%)，セカンダリの所持枠+1

**もろもろ**
タクティカルレギンスのリロード速度上昇率を30%->20%にした
ロケットランチャーの爆風で死んだときの死亡メッセージを追加
ロケットランチャーの爆発エフェクトを変更
銃撃戦中に座ってしまわないように，素手でないと座れないようにした
タクティカルレギンス・ベストを召喚時ランダムな色に染色されるように
インベントリ操作でオフハンドに物を持ててしまわないようにした