### PR TITLE
銃チケット・銃ショップ実装

### DIFF
--- a/src/main/java/space/yurisi/universecorev2/command/giveuCommand.java
+++ b/src/main/java/space/yurisi/universecorev2/command/giveuCommand.java
@@ -37,7 +37,7 @@ public class giveuCommand implements CommandExecutor, TabCompleter {
             §6-- Give Universe Item Help --
                §7/giveu add <ID> [レベル] [アイテム数] : 指定されたIDのアイテムをインベントリに追加します
                §7/giveu list : 入手可能なアイテムのリストを表示します
-               §7/giveu ticket gacha/gun [枚数] : ガチャや銃のチケットを指定した枚数分インベントリに追加します
+               §7/giveu ticket <gacha | gun> [枚数] : ガチャや銃のチケットを指定した枚数分インベントリに追加します
                §7/giveu help : このヘルプを表示します
             """.split("\n");
 
@@ -99,9 +99,23 @@ public class giveuCommand implements CommandExecutor, TabCompleter {
             case "ticket":
                 int amount;
 
-                if (args.length < 3) {
+                if (args.length < 2) {
                     Message.sendErrorMessage(player, "[管理AI]", "チケットの種類をgachaかgunで指定してください。");
+                    return false;
+                }
+
+                if(args.length < 3){
                     Message.sendErrorMessage(player, "[管理AI]", "枚数を指定してください。");
+                }
+
+                String ticketType = args[1];
+                ItemStack ticket;
+                if(ticketType.equalsIgnoreCase("gacha")){
+                    ticket = UniverseItem.getItem(GachaTicket.id).getItem();
+                } else if(ticketType.equalsIgnoreCase("gun")) {
+                    ticket = UniverseItem.getItem(GunTicket.id).getItem();
+                } else {
+                    Message.sendErrorMessage(player, "[管理AI]", "チケットの種類をgachaかgunで指定してください。");
                     return false;
                 }
 
@@ -114,17 +128,6 @@ public class giveuCommand implements CommandExecutor, TabCompleter {
 
                 if (player.getInventory().firstEmpty() == -amount) {
                     Message.sendErrorMessage(player, "[管理AI]", "インベントリに空きがありません。");
-                    return false;
-                }
-
-                String ticketType = args[1];
-                ItemStack ticket;
-                if(ticketType.equalsIgnoreCase("gacha")){
-                    ticket = UniverseItem.getItem(GachaTicket.id).getItem();
-                } else if(ticketType.equalsIgnoreCase("gun")) {
-                    ticket = UniverseItem.getItem(GunTicket.id).getItem();
-                } else {
-                    Message.sendErrorMessage(player, "[管理AI]", "チケットの種類をgachaかgunで指定してください。");
                     return false;
                 }
 

--- a/src/main/java/space/yurisi/universecorev2/command/giveuCommand.java
+++ b/src/main/java/space/yurisi/universecorev2/command/giveuCommand.java
@@ -14,6 +14,7 @@ import space.yurisi.universecorev2.item.CustomItem;
 import space.yurisi.universecorev2.item.LevellingCustomItem;
 import space.yurisi.universecorev2.item.UniverseItem;
 import space.yurisi.universecorev2.item.ticket.GachaTicket;
+import space.yurisi.universecorev2.item.ticket.GunTicket;
 import space.yurisi.universecorev2.utils.Message;
 
 import java.util.ArrayList;
@@ -36,7 +37,7 @@ public class giveuCommand implements CommandExecutor, TabCompleter {
             §6-- Give Universe Item Help --
                §7/giveu add <ID> [レベル] [アイテム数] : 指定されたIDのアイテムをインベントリに追加します
                §7/giveu list : 入手可能なアイテムのリストを表示します
-               §7/giveu ticket [枚数] : チケットを指定した枚数分インベントリに追加します
+               §7/giveu ticket gacha/gun [枚数] : ガチャや銃のチケットを指定した枚数分インベントリに追加します
                §7/giveu help : このヘルプを表示します
             """.split("\n");
 
@@ -98,13 +99,14 @@ public class giveuCommand implements CommandExecutor, TabCompleter {
             case "ticket":
                 int amount;
 
-                if (args.length < 2) {
+                if (args.length < 3) {
+                    Message.sendErrorMessage(player, "[管理AI]", "チケットの種類をgachaかgunで指定してください。");
                     Message.sendErrorMessage(player, "[管理AI]", "枚数を指定してください。");
                     return false;
                 }
 
                 try {
-                    amount = Integer.parseInt(args[1]);
+                    amount = Integer.parseInt(args[2]);
                 } catch (NumberFormatException e) {
                     Message.sendErrorMessage(player, "[管理AI]", "枚数は数値で指定してください。");
                     return false;
@@ -115,7 +117,17 @@ public class giveuCommand implements CommandExecutor, TabCompleter {
                     return false;
                 }
 
-                ItemStack ticket = UniverseItem.getItem(GachaTicket.id).getItem();
+                String ticketType = args[1];
+                ItemStack ticket;
+                if(ticketType.equalsIgnoreCase("gacha")){
+                    ticket = UniverseItem.getItem(GachaTicket.id).getItem();
+                } else if(ticketType.equalsIgnoreCase("gun")) {
+                    ticket = UniverseItem.getItem(GunTicket.id).getItem();
+                } else {
+                    Message.sendErrorMessage(player, "[管理AI]", "チケットの種類をgachaかgunで指定してください。");
+                    return false;
+                }
+
                 for (int i = 1; i <= amount; i++) {
                     player.getInventory().addItem(ticket);
                 }

--- a/src/main/java/space/yurisi/universecorev2/constants/UniverseItemKeyString.java
+++ b/src/main/java/space/yurisi/universecorev2/constants/UniverseItemKeyString.java
@@ -5,6 +5,7 @@ public class UniverseItemKeyString {
     public static final String ITEM_NAME = "item_name";
     public static final String LEVEL = "level";
     public static final String GACHA_TICKET = "gacha_ticket";
+    public static final String GUN_TICKET = "gun_ticket";
     public static final String FISH = "fish";
     public static final String FISH_SIZE = "fish_size";
     public static final String GUN = "gun";

--- a/src/main/java/space/yurisi/universecorev2/item/UniverseItem.java
+++ b/src/main/java/space/yurisi/universecorev2/item/UniverseItem.java
@@ -17,6 +17,7 @@ import space.yurisi.universecorev2.item.repair_cream.RepairCream;
 import space.yurisi.universecorev2.item.solar_system.*;
 import space.yurisi.universecorev2.item.stick.BlockCopyStick;
 import space.yurisi.universecorev2.item.ticket.GachaTicket;
+import space.yurisi.universecorev2.item.ticket.GunTicket;
 import space.yurisi.universecorev2.menu.MainMenu;
 
 import java.util.HashMap;
@@ -39,6 +40,7 @@ public class UniverseItem {
         items.put(SolarSystemLeggings.id, new SolarSystemLeggings());
         items.put(SolarSystemBoots.id, new SolarSystemBoots());
         items.put(GachaTicket.id, new GachaTicket());
+        items.put(GunTicket.id, new GunTicket());
         items.put(RepairCream.id, new RepairCream());
         items.put(BlockCopyStick.id, new BlockCopyStick());
         items.put(FishingRod.id, new FishingRod());
@@ -91,9 +93,11 @@ public class UniverseItem {
     }
 
 
-    public static Boolean removeItem(Player player, String item_name){
+    public static Boolean removeItem(Player player, String item_name, int amount){
         PlayerInventory inventory = player.getInventory();
         NamespacedKey itemKey = new NamespacedKey(UniverseCoreV2.getInstance(), UniverseItemKeyString.ITEM_NAME);
+        int remainingAmount = amount;
+        int totalAmount = 0;
 
         for (ItemStack item : inventory.getContents()) {
             if (item != null && item.hasItemMeta()) {
@@ -104,12 +108,41 @@ public class UniverseItem {
                     String isGachaTicket = container.get(itemKey, PersistentDataType.STRING);
 
                     if (Objects.equals(isGachaTicket, item_name)) {
-                        if (item.getAmount() > 1) {
-                            item.setAmount(item.getAmount() - 1);
-                        } else {
-                            inventory.remove(item);
+                        totalAmount += item.getAmount();
+                        if(totalAmount >= amount){
+                            break;
                         }
-                        return true;
+                    }
+                }
+            }
+        }
+
+        if (totalAmount < amount) {
+            return false;
+        }
+
+        for (ItemStack item : inventory.getContents()) {
+            if (item != null && item.hasItemMeta()) {
+                ItemMeta meta = item.getItemMeta();
+                PersistentDataContainer container = meta.getPersistentDataContainer();
+
+                if (container.has(itemKey, PersistentDataType.STRING)) {
+                    String isGachaTicket = container.get(itemKey, PersistentDataType.STRING);
+
+                    if (Objects.equals(isGachaTicket, item_name)) {
+                        int itemAmount = item.getAmount();
+                        if (itemAmount <= remainingAmount) {
+                            remainingAmount -= itemAmount;
+                            player.sendMessage(remainingAmount + " " + item_name);
+                            item.setAmount(0);
+                        } else {
+                            item.setAmount(itemAmount - remainingAmount);
+                            remainingAmount = 0;
+                        }
+
+                        if (remainingAmount == 0) {
+                            return true;
+                        }
                     }
                 }
             }

--- a/src/main/java/space/yurisi/universecorev2/item/gun/F2.java
+++ b/src/main/java/space/yurisi/universecorev2/item/gun/F2.java
@@ -39,6 +39,8 @@ public final class F2 extends Gun {
         this.volumeSound = 5.0F;
         this.pitchSound = 0.8F;
         this.flavorText = "§7フランスで開発された3点バースト式のアサルトライフル。高いレートと命中精度が特徴";
+        this.textureNumber = 5;
+        this.price = 4;
     }
 
     @Override
@@ -46,7 +48,7 @@ public final class F2 extends Gun {
         default_setting = (item) -> {
             ItemMeta meta = item.getItemMeta();
             if (meta != null) {
-                meta.setCustomModelData(5);
+                meta.setCustomModelData(textureNumber);
             }
             item.setItemMeta(meta);
             return item;

--- a/src/main/java/space/yurisi/universecorev2/item/gun/Gun.java
+++ b/src/main/java/space/yurisi/universecorev2/item/gun/Gun.java
@@ -66,6 +66,10 @@ public abstract class Gun extends CustomItem {
 
     protected String flavorText;
 
+    protected int textureNumber;
+
+    protected int price;
+
     public Gun(String id, String name, ItemStack baseItem) {
         super(id, name, baseItem);
     }
@@ -151,6 +155,18 @@ public abstract class Gun extends CustomItem {
         return pitchSound;
     }
 
+    public String getFlavorText(){
+        return flavorText;
+    }
+
+    public int getTextureNumber(){
+        return textureNumber;
+    }
+
+    public int getPrice(){
+        return price;
+    }
+
     @Override
     public ItemStack getItem(){
         ItemStack item = getBaseItem().clone();
@@ -160,14 +176,14 @@ public abstract class Gun extends CustomItem {
         container.set(new NamespacedKey(UniverseCoreV2.getInstance(), UniverseItemKeyString.GUN), PersistentDataType.BOOLEAN, true);
         container.set(new NamespacedKey(UniverseCoreV2.getInstance(), UniverseItemKeyString.GUN_SERIAL), PersistentDataType.STRING, UUID.randomUUID().toString());
         meta.displayName(Component.text(name));
-        List<Component> lore = getComponents();
+        List<Component> lore = getGunComponents();
         meta.lore(lore);
         item.setItemMeta(meta);
         return default_setting.apply(item);
     }
 
-    private @NotNull List<Component> getComponents() {
-        String category = "§7カテゴリ: ";
+    public @NotNull List<Component> getGunComponents() {
+        String category = "§7カテゴリ: §b";
         switch (type){
             case AR:
                 category += "アサルトライフル";
@@ -191,7 +207,7 @@ public abstract class Gun extends CustomItem {
                 category += "特殊系";
                 break;
         }
-        String equipmentCategory = "§7装備カテゴリ: ";
+        String equipmentCategory = "§7装備カテゴリ: §b";
         switch (equipmentType){
             case PRIMARY:
                 equipmentCategory += "プライマリ";
@@ -203,9 +219,8 @@ public abstract class Gun extends CustomItem {
         List<Component> lore = List.of(
                 Component.text(category),
                 Component.text(equipmentCategory),
-                Component.text("§7マガジンサイズ: " + magazineSize),
-                Component.text("§7リロード時間: " + (double)reloadTime/1000 + "s"),
-                Component.text(flavorText)
+                Component.text("§7マガジンサイズ: §b" + magazineSize),
+                Component.text("§7リロード時間: §b" + (double)reloadTime/1000 + "§7秒")
         );
         return lore;
     }

--- a/src/main/java/space/yurisi/universecorev2/item/gun/L96A1.java
+++ b/src/main/java/space/yurisi/universecorev2/item/gun/L96A1.java
@@ -38,6 +38,8 @@ public final class L96A1 extends Gun {
         this.volumeSound = 10.0F;
         this.pitchSound = 0.8F;
         this.flavorText = "§7イギリスで使用される軍用ボルトアクション式スナイパーライフル";
+        this.textureNumber = 2;
+        this.price = 10;
     }
 
     @Override
@@ -45,7 +47,7 @@ public final class L96A1 extends Gun {
         default_setting = (item) -> {
             ItemMeta meta = item.getItemMeta();
             if (meta != null) {
-                meta.setCustomModelData(2);
+                meta.setCustomModelData(textureNumber);
             }
             item.setItemMeta(meta);
             return item;

--- a/src/main/java/space/yurisi/universecorev2/item/gun/L96A1.java
+++ b/src/main/java/space/yurisi/universecorev2/item/gun/L96A1.java
@@ -17,7 +17,7 @@ public final class L96A1 extends Gun {
                 ItemStack.of(Material.DIAMOND_HOE)
         );
 
-        this.type = GunType.SR_SEMI;
+        this.type = GunType.SR_BOLT;
         this.equipmentType = GunType.PRIMARY;
         this.magazineSize = 5;
         this.burst = 0;

--- a/src/main/java/space/yurisi/universecorev2/item/gun/M1911.java
+++ b/src/main/java/space/yurisi/universecorev2/item/gun/M1911.java
@@ -39,6 +39,8 @@ public final class M1911 extends Gun {
         this.volumeSound = 5.0F;
         this.pitchSound = 2.0F;
         this.flavorText = "§7アメリカで開発された自動拳銃。第一次世界大戦時代に生まれ、現在でも多くの国で使用されている";
+        this.textureNumber = 7;
+        this.price = 1;
     }
 
     @Override
@@ -46,7 +48,7 @@ public final class M1911 extends Gun {
         default_setting = (item) -> {
             ItemMeta meta = item.getItemMeta();
             if (meta != null) {
-                meta.setCustomModelData(7);
+                meta.setCustomModelData(textureNumber);
             }
             item.setItemMeta(meta);
             return item;

--- a/src/main/java/space/yurisi/universecorev2/item/gun/M870.java
+++ b/src/main/java/space/yurisi/universecorev2/item/gun/M870.java
@@ -39,6 +39,8 @@ public final class M870 extends Gun {
         this.volumeSound = 5.0F;
         this.pitchSound = 0.6F;
         this.flavorText = "§7ポンプアクション式ショットガン。有効射程が長いが連射速度は遅い";
+        this.textureNumber = 6;
+        this.price = 5;
     }
 
     @Override
@@ -46,7 +48,7 @@ public final class M870 extends Gun {
         default_setting = (item) -> {
             ItemMeta meta = item.getItemMeta();
             if (meta != null) {
-                meta.setCustomModelData(6);
+                meta.setCustomModelData(textureNumber);
             }
             item.setItemMeta(meta);
             return item;

--- a/src/main/java/space/yurisi/universecorev2/item/gun/R4C.java
+++ b/src/main/java/space/yurisi/universecorev2/item/gun/R4C.java
@@ -38,6 +38,8 @@ public final class R4C extends Gun {
         this.volumeSound = 4.0F;
         this.pitchSound = 1.8F;
         this.flavorText = "§7威力は低いものの高い連射速度でレインボーな特殊部隊に愛用されている";
+        this.textureNumber = 1;
+        this.price = 5;
     }
 
 
@@ -46,7 +48,7 @@ public final class R4C extends Gun {
         default_setting = (item) -> {
             ItemMeta meta = item.getItemMeta();
             if (meta != null) {
-                meta.setCustomModelData(1);
+                meta.setCustomModelData(textureNumber);
             }
             item.setItemMeta(meta);
             return item;

--- a/src/main/java/space/yurisi/universecorev2/item/gun/RPG.java
+++ b/src/main/java/space/yurisi/universecorev2/item/gun/RPG.java
@@ -39,6 +39,8 @@ public final class RPG extends Gun {
         this.volumeSound = 10.0F;
         this.pitchSound = 0.5F;
         this.flavorText = "§7ロケットランチャーの代名詞。爆風で広範囲にダメージを与える";
+        this.textureNumber = 3;
+        this.price = 10;
     }
 
     @Override
@@ -46,7 +48,7 @@ public final class RPG extends Gun {
         default_setting = (item) -> {
             ItemMeta meta = item.getItemMeta();
             if (meta != null) {
-                meta.setCustomModelData(3);
+                meta.setCustomModelData(textureNumber);
             }
             item.setItemMeta(meta);
             return item;

--- a/src/main/java/space/yurisi/universecorev2/item/gun/SMG11.java
+++ b/src/main/java/space/yurisi/universecorev2/item/gun/SMG11.java
@@ -38,6 +38,8 @@ public final class SMG11 extends Gun {
         this.volumeSound = 3.0F;
         this.pitchSound = 0.8F;
         this.flavorText = "§7随一の連射速度と軽量さが特徴のサブマシンガン。覗かないとまともに当たらない";
+        this.textureNumber = 4;
+        this.price = 2;
     }
 
     @Override
@@ -45,7 +47,7 @@ public final class SMG11 extends Gun {
         default_setting = (item) -> {
             ItemMeta meta = item.getItemMeta();
             if (meta != null) {
-                meta.setCustomModelData(4);
+                meta.setCustomModelData(textureNumber);
             }
             item.setItemMeta(meta);
             return item;

--- a/src/main/java/space/yurisi/universecorev2/item/ticket/GunTicket.java
+++ b/src/main/java/space/yurisi/universecorev2/item/ticket/GunTicket.java
@@ -1,0 +1,37 @@
+package space.yurisi.universecorev2.item.ticket;
+
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+import space.yurisi.universecorev2.UniverseCoreV2;
+import space.yurisi.universecorev2.constants.UniverseItemKeyString;
+import space.yurisi.universecorev2.item.CustomItem;
+
+public class GunTicket extends CustomItem {
+
+    public static final String id = "gun_ticket";
+
+    public GunTicket() {
+        super(
+                id,
+                "§e§l銃チケット",
+                ItemStack.of(Material.PAPER)
+        );
+    }
+
+    @Override
+    protected void registerItemFunction() {
+        default_setting = (item) -> {
+            ItemMeta meta = item.getItemMeta();
+            if (meta != null) {
+                PersistentDataContainer container = meta.getPersistentDataContainer();
+                container.set(new NamespacedKey(UniverseCoreV2.getInstance(), UniverseItemKeyString.GUN_TICKET), PersistentDataType.BOOLEAN, true);
+                item.setItemMeta(meta);
+            }
+            return item;
+        };
+    }
+}

--- a/src/main/java/space/yurisi/universecorev2/subplugins/gacha/core/event/EventGacha.java
+++ b/src/main/java/space/yurisi/universecorev2/subplugins/gacha/core/event/EventGacha.java
@@ -44,7 +44,7 @@ public abstract class EventGacha {
     }
 
     public void turn() {
-        Boolean ticket = UniverseItem.removeItem(player, "gacha_ticket");
+        Boolean ticket = UniverseItem.removeItem(player, "gacha_ticket", 1);
 
         if (player.getInventory().firstEmpty() == -1) {
             Message.sendErrorMessage(player, "[ガチャAI]", "インベントリがいっぱいです。(スタックが余ってる場合も一度しまって下さい。)");

--- a/src/main/java/space/yurisi/universecorev2/subplugins/repaircream/command/repairCommand.java
+++ b/src/main/java/space/yurisi/universecorev2/subplugins/repaircream/command/repairCommand.java
@@ -39,7 +39,7 @@ public class repairCommand implements CommandExecutor {
             return false;
         }
 
-        Boolean ticket = UniverseItem.removeItem(player, "repair_cream");
+        Boolean ticket = UniverseItem.removeItem(player, "repair_cream", 1);
 
         if (!ticket) {
             Message.sendErrorMessage(player, "[修復AI]", "修復クリームが足りません。");

--- a/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/UniverseGuns.java
+++ b/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/UniverseGuns.java
@@ -4,7 +4,8 @@ import space.yurisi.universecorev2.UniverseCoreV2;
 import space.yurisi.universecorev2.UniverseCoreV2API;
 import space.yurisi.universecorev2.database.DatabaseManager;
 import space.yurisi.universecorev2.subplugins.SubPlugin;
-import space.yurisi.universecorev2.subplugins.universeguns.command.GunCommand;
+import space.yurisi.universecorev2.subplugins.universeguns.command.*;
+import space.yurisi.universecorev2.subplugins.universeguns.event.EntityInteract;
 import space.yurisi.universecorev2.subplugins.universeguns.event.GunEvent;
 import space.yurisi.universecorev2.subplugins.universeguns.connector.UniverseCoreAPIConnector;
 
@@ -17,7 +18,10 @@ public class UniverseGuns implements SubPlugin {
         DatabaseManager manager = UniverseCoreV2API.getInstance().getDatabaseManager();
         this.connector = new UniverseCoreAPIConnector(manager);
         core.getServer().getPluginManager().registerEvents(new GunEvent(core, connector), core);
+        core.getServer().getPluginManager().registerEvents(new EntityInteract(), core);
         core.getCommand("ammo").setExecutor(new GunCommand(connector));
+        core.getCommand("spawnGunClerk").setExecutor(new SpawnGunShopClerkCommand());
+        core.getCommand("killGunClerk").setExecutor(new KillGunShopClerkCommand());
     }
 
     public void onDisable() {
@@ -31,6 +35,6 @@ public class UniverseGuns implements SubPlugin {
 
     @Override
     public String getVersion() {
-        return "1.0.1";
+        return "1.1.1";
     }
 }

--- a/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/command/GunCommand.java
+++ b/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/command/GunCommand.java
@@ -7,7 +7,7 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import space.yurisi.universecorev2.subplugins.universeguns.connector.UniverseCoreAPIConnector;
-import space.yurisi.universecorev2.subplugins.universeguns.menu.AmmoManagerInventoryMenu;
+import space.yurisi.universecorev2.subplugins.universeguns.menu.ammo_menu.AmmoManagerInventoryMenu;
 
 public class GunCommand implements CommandExecutor {
 
@@ -27,7 +27,6 @@ public class GunCommand implements CommandExecutor {
         AmmoManagerInventoryMenu ammoManagerInventoryMenu = new AmmoManagerInventoryMenu(connector);
         ammoManagerInventoryMenu.sendMenu(player);
 
-//        Message.sendSuccessMessage(player, "[武器AI]", "弾薬管理メニューを開きました");
         return true;
     }
 }

--- a/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/command/KillGunShopClerkCommand.java
+++ b/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/command/KillGunShopClerkCommand.java
@@ -1,0 +1,50 @@
+package space.yurisi.universecorev2.subplugins.universeguns.command;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import space.yurisi.universecorev2.api.LuckPermsWrapper;
+import space.yurisi.universecorev2.subplugins.universeguns.constants.ShopType;
+import space.yurisi.universecorev2.subplugins.universeguns.entity.GunShopClerk;
+import space.yurisi.universecorev2.utils.Message;
+
+public class KillGunShopClerkCommand implements CommandExecutor {
+
+    @Override
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+        if(!(sender instanceof Player player)) {
+            return false;
+        }
+
+        if (!LuckPermsWrapper.isUserInAdminOrDevGroup(player)) {
+            Message.sendErrorMessage(player, "[管理AI]", "このコマンドを実行する権限がありません。");
+            return false;
+        }
+
+        if(args == null || args.length < 1) {
+            Message.sendErrorMessage(player, "[武器AI]", "ショップの種類を指定してください。");
+            Message.sendErrorMessage(player, "[武器AI]", "hg | smg | sg");
+            Message.sendErrorMessage(player, "[武器AI]", "ar | sr");
+            Message.sendErrorMessage(player, "[武器AI]", "lmg | ex |　armor");
+            return false;
+        }
+
+        String strShopType = args[0];
+        for(ShopType shopType : ShopType.values()) {
+            if(shopType.getName().equals(strShopType)) {
+                if(GunShopClerk.killClerk(player.getLocation(), shopType)) {
+                    Message.sendSuccessMessage(player, "[武器AI]", "指定されたショップの店員を削除しました。");
+                }else{
+                    Message.sendWarningMessage(player, "[武器AI]", "指定されたショップの店員が見つかりませんでした。");
+                }
+                return true;
+            }
+        }
+
+        Message.sendWarningMessage(player, "[武器AI]", "指定されたショップが見つかりませんでした。");
+
+        return false;
+    }
+}

--- a/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/command/SpawnGunShopClerkCommand.java
+++ b/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/command/SpawnGunShopClerkCommand.java
@@ -1,0 +1,47 @@
+package space.yurisi.universecorev2.subplugins.universeguns.command;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import space.yurisi.universecorev2.api.LuckPermsWrapper;
+import space.yurisi.universecorev2.subplugins.universeguns.constants.ShopType;
+import space.yurisi.universecorev2.subplugins.universeguns.entity.GunShopClerk;
+import space.yurisi.universecorev2.utils.Message;
+
+public class SpawnGunShopClerkCommand implements CommandExecutor {
+
+    @Override
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+        if(!(sender instanceof Player player)) {
+            return false;
+        }
+
+        if (!LuckPermsWrapper.isUserInAdminOrDevGroup(player)) {
+            Message.sendErrorMessage(player, "[管理AI]", "このコマンドを実行する権限がありません。");
+            return false;
+        }
+
+        if(args == null || args.length < 1) {
+            Message.sendErrorMessage(player, "[武器AI]", "ショップの種類を指定してください。");
+            Message.sendErrorMessage(player, "[武器AI]", "hg | smg | sg");
+            Message.sendErrorMessage(player, "[武器AI]", "ar | sr");
+            Message.sendErrorMessage(player, "[武器AI]", "lmg | ex |　armor");
+            return false;
+        }
+
+        String strShopType = args[0];
+        for(ShopType shopType : ShopType.values()) {
+            if(shopType.getName().equals(strShopType)) {
+                GunShopClerk gunShopClerk = new GunShopClerk();
+                gunShopClerk.spawnClerk(player.getLocation(), shopType);
+                return true;
+            }
+        }
+
+        Message.sendWarningMessage(player, "[武器AI]", "指定されたショップが見つかりませんでした。");
+
+        return false;
+    }
+}

--- a/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/constants/ShopType.java
+++ b/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/constants/ShopType.java
@@ -1,0 +1,24 @@
+package space.yurisi.universecorev2.subplugins.universeguns.constants;
+
+public enum ShopType {
+
+    HGShop("hg"),
+    SMGShop("smg"),
+    SGShop("sg"),
+    ARShop("ar"),
+    SRShop("sr"),
+    LMGShop("lmg"),
+    EXShop("ex"),
+    EQUIPMENTShop("armor");
+
+    private String name;
+
+    ShopType(String name){
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+}

--- a/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/core/PurchaseGun.java
+++ b/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/core/PurchaseGun.java
@@ -1,0 +1,46 @@
+package space.yurisi.universecorev2.subplugins.universeguns.core;
+
+import org.bukkit.Sound;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import space.yurisi.universecorev2.item.CustomItem;
+import space.yurisi.universecorev2.item.UniverseItem;
+import space.yurisi.universecorev2.item.gun.Gun;
+import space.yurisi.universecorev2.subplugins.receivebox.ReceiveBoxAPI;
+import space.yurisi.universecorev2.utils.Message;
+
+import java.util.Date;
+
+public class PurchaseGun {
+
+    public static void executePurchase(Player player, Gun gun) {
+        Boolean canPurchase = UniverseItem.removeItem(player, "gun_ticket", gun.getPrice());
+
+        if(!canPurchase) {
+            Message.sendWarningMessage(player, "[武器AI]", "チケットが足りません。");
+            player.playSound(player.getLocation(), Sound.ENTITY_VILLAGER_NO, 1, 1);
+            return;
+        }
+
+        CustomItem item = UniverseItem.getItem(gun.getId());
+        if(item == null) {
+            player.playSound(player.getLocation(), Sound.ENTITY_VILLAGER_NO, 1, 1);
+            Message.sendErrorMessage(player, "[武器AI]", "アイテムが見つかりませんでした。運営にお問い合わせください。");
+            return;
+        }
+        Inventory inventory = player.getInventory();
+        ItemStack itemStack = item.getItem();
+
+        if(inventory.firstEmpty() == -1) {
+            player.playSound(player.getLocation(), Sound.ENTITY_VILLAGER_YES, 1, 1);
+            Message.sendWarningMessage(player, "[武器AI]", "インベントリがいっぱいなので、受け取りboxに送りました。");
+            Date expireDate = new Date(System.currentTimeMillis() + 1000 * 60 * 60 * 24 * 7);
+            ReceiveBoxAPI.AddReceiveItem(itemStack, player.getUniqueId(), expireDate, "購入した武器");
+            return;
+        }
+
+        inventory.addItem(itemStack);
+        player.playSound(player.getLocation(), Sound.ENTITY_VILLAGER_CELEBRATE, 1, 1);
+    }
+}

--- a/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/core/PurchaseGun.java
+++ b/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/core/PurchaseGun.java
@@ -34,13 +34,15 @@ public class PurchaseGun {
 
         if(inventory.firstEmpty() == -1) {
             player.playSound(player.getLocation(), Sound.ENTITY_VILLAGER_YES, 1, 1);
-            Message.sendWarningMessage(player, "[武器AI]", "インベントリがいっぱいなので、受け取りboxに送りました。");
+            Message.sendSuccessMessage(player, "[武器AI]", "インベントリがいっぱいなので、受け取りboxに送りました。");
+            Message.sendSuccessMessage(player, "[武器AI]", "受け取りboxは /receive で確認できます。");
             Date expireDate = new Date(System.currentTimeMillis() + 1000 * 60 * 60 * 24 * 7);
             ReceiveBoxAPI.AddReceiveItem(itemStack, player.getUniqueId(), expireDate, "購入した武器");
             return;
         }
 
         inventory.addItem(itemStack);
+        Message.sendSuccessMessage(player, "[武器AI]", gun.getName() + "を購入しました。");
         player.playSound(player.getLocation(), Sound.ENTITY_VILLAGER_CELEBRATE, 1, 1);
     }
 }

--- a/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/entity/GunShopClerk.java
+++ b/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/entity/GunShopClerk.java
@@ -1,0 +1,86 @@
+package space.yurisi.universecorev2.subplugins.universeguns.entity;
+
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.World;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Villager;
+import org.bukkit.Location;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.persistence.PersistentDataType;
+import space.yurisi.universecorev2.UniverseCoreV2;
+import space.yurisi.universecorev2.subplugins.universeguns.constants.ShopType;
+
+
+public class GunShopClerk {
+
+    public void spawnClerk(Location location, ShopType shopType) {
+        // Thanks to Charindo
+        World world = location.getWorld();
+        Villager villager = (Villager) world.spawnEntity(location, EntityType.VILLAGER);
+        villager.setCustomName(getDisplayName(shopType));
+        villager.setCustomNameVisible(true);
+        villager.getEquipment().setItemInMainHand(new ItemStack(Material.AIR));
+        villager.getEquipment().setItemInOffHand(new ItemStack(Material.AIR));
+        villager.getEquipment().setHelmet(new ItemStack(Material.AIR));
+        villager.getEquipment().setChestplate(new ItemStack(Material.AIR));
+        villager.getEquipment().setLeggings(new ItemStack(Material.AIR));
+        villager.getEquipment().setBoots(new ItemStack(Material.AIR));
+        villager.getPersistentDataContainer().set(new NamespacedKey(UniverseCoreV2.getInstance(), shopType.getName()),
+                PersistentDataType.STRING, shopType.getName());
+        villager.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED).setBaseValue(0.0D);
+        villager.getAttribute(Attribute.GENERIC_ATTACK_KNOCKBACK).setBaseValue(0.0D);
+        villager.setCollidable(false);
+        villager.setSilent(true);
+        villager.setInvulnerable(true);
+    }
+
+    public static ShopType getShopType(Entity entity) {
+        if(entity instanceof Villager villager) {
+            for(ShopType shopType : ShopType.values()) {
+                if(villager.getPersistentDataContainer().has(new NamespacedKey(UniverseCoreV2.getInstance(), shopType.getName()), PersistentDataType.STRING)) {
+                    return shopType;
+                }
+            }
+        }
+        return null;
+    }
+
+    public static boolean killClerk(Location location, ShopType shopType) {
+        for(Entity entity : location.getWorld().getNearbyEntities(location, 5, 5, 5)) {
+            if(entity instanceof Villager villager) {
+                if(villager.getPersistentDataContainer().has(new NamespacedKey(UniverseCoreV2.getInstance(), shopType.getName()), PersistentDataType.STRING)) {
+                    villager.remove();
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private String getDisplayName(ShopType shopType) {
+        switch (shopType){
+            case HGShop:
+                return "ハンドガン";
+            case SMGShop:
+                return "サブマシンガン";
+            case SGShop:
+                return "ショットガン";
+            case ARShop:
+                return "アサルトライフル";
+            case SRShop:
+                return "スナイパーライフル";
+            case LMGShop:
+                return "ライトマシンガン";
+            case EXShop:
+                return "特殊武器";
+            case EQUIPMENTShop:
+                return "装具類";
+            default:
+                return null;
+        }
+    }
+}

--- a/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/event/EntityInteract.java
+++ b/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/event/EntityInteract.java
@@ -1,0 +1,64 @@
+package space.yurisi.universecorev2.subplugins.universeguns.event;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.player.PlayerInteractEntityEvent;
+import space.yurisi.universecorev2.subplugins.universeguns.constants.ShopType;
+import space.yurisi.universecorev2.subplugins.universeguns.entity.GunShopClerk;
+import space.yurisi.universecorev2.subplugins.universeguns.menu.shop_menu.*;
+
+public class EntityInteract implements Listener{
+
+    @EventHandler
+    public void onEntityInteract(PlayerInteractEntityEvent event) {
+        ShopType shopType = GunShopClerk.getShopType(event.getRightClicked());
+        if(shopType == null) {
+            return;
+        }
+        Player player = event.getPlayer();
+        event.setCancelled(true);
+
+        switch (shopType) {
+            case HGShop:
+                HandGunShopMenu handGunShopMenu = new HandGunShopMenu();
+                handGunShopMenu.sendMenu(player);
+                break;
+            case SMGShop:
+                SubMachineGunShopMenu subMachineGunShopMenu = new SubMachineGunShopMenu();
+                subMachineGunShopMenu.sendMenu(player);
+                break;
+            case SGShop:
+                ShotGunShopMenu shotGunShopMenu = new ShotGunShopMenu();
+                shotGunShopMenu.sendMenu(player);
+                break;
+            case ARShop:
+                AssultRifleShopMenu assultRifleShopMenu = new AssultRifleShopMenu();
+                assultRifleShopMenu.sendMenu(player);
+                break;
+            case SRShop:
+                SniperRifleShopMenu sniperRifleShopMenu = new SniperRifleShopMenu();
+                sniperRifleShopMenu.sendMenu(player);
+                break;
+            case LMGShop:
+                break;
+            case EXShop:
+                ExplosiveShopMenu explosiveShopMenu = new ExplosiveShopMenu();
+                explosiveShopMenu.sendMenu(player);
+                break;
+            case EQUIPMENTShop:
+                break;
+        }
+    }
+
+    @EventHandler
+    public void onEntityDamageByEntity(EntityDamageByEntityEvent event) {
+        if (event.getDamager() instanceof Player) {
+            ShopType shopType = GunShopClerk.getShopType(event.getEntity());
+            if(shopType != null) {
+                event.setCancelled(true);
+            }
+        }
+    }
+}

--- a/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/event/GunEvent.java
+++ b/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/event/GunEvent.java
@@ -14,7 +14,6 @@ import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityPickupItemEvent;
 import org.bukkit.event.entity.ProjectileHitEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
-import org.bukkit.event.inventory.InventoryDragEvent;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.inventory.PrepareItemCraftEvent;
 import org.bukkit.event.player.*;
@@ -41,14 +40,13 @@ import space.yurisi.universecorev2.subplugins.universeguns.core.DamageCalculator
 import space.yurisi.universecorev2.subplugins.universeguns.core.EquipmentLimit;
 import space.yurisi.universecorev2.subplugins.universeguns.core.GunStatus;
 import space.yurisi.universecorev2.subplugins.universeguns.manager.GunStatusManager;
-import space.yurisi.universecorev2.subplugins.universeguns.menu.AmmoManagerInventoryMenu;
+import space.yurisi.universecorev2.subplugins.universeguns.menu.ammo_menu.AmmoManagerInventoryMenu;
 import space.yurisi.universecorev2.utils.Message;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Objects;
-import java.util.Arrays;
 
 public class GunEvent implements Listener {
 

--- a/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/menu/ammo_menu/AmmoManagerInventoryMenu.java
+++ b/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/menu/ammo_menu/AmmoManagerInventoryMenu.java
@@ -1,14 +1,12 @@
-package space.yurisi.universecorev2.subplugins.universeguns.menu;
+package space.yurisi.universecorev2.subplugins.universeguns.menu.ammo_menu;
 
 import org.bukkit.Material;
-import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
-import space.yurisi.universecorev2.exception.AmmoNotFoundException;
 import space.yurisi.universecorev2.exception.UserNotFoundException;
 import space.yurisi.universecorev2.menu.BaseMenu;
 import space.yurisi.universecorev2.subplugins.universeguns.connector.UniverseCoreAPIConnector;
-import space.yurisi.universecorev2.subplugins.universeguns.menu.item.*;
+import space.yurisi.universecorev2.subplugins.universeguns.menu.ammo_menu.item.*;
 import space.yurisi.universecorev2.utils.Message;
 import xyz.xenondevs.invui.gui.Gui;
 import xyz.xenondevs.invui.item.Item;

--- a/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/menu/ammo_menu/item/AmmoItem.java
+++ b/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/menu/ammo_menu/item/AmmoItem.java
@@ -1,4 +1,4 @@
-package space.yurisi.universecorev2.subplugins.universeguns.menu.item;
+package space.yurisi.universecorev2.subplugins.universeguns.menu.ammo_menu.item;
 
 import org.bukkit.Material;
 import org.bukkit.Sound;
@@ -15,7 +15,7 @@ import space.yurisi.universecorev2.subplugins.universeeconomy.exception.CanNotRe
 import space.yurisi.universecorev2.subplugins.universeeconomy.exception.ParameterException;
 import space.yurisi.universecorev2.subplugins.universeguns.connector.UniverseCoreAPIConnector;
 import space.yurisi.universecorev2.subplugins.universeguns.constants.GunType;
-import space.yurisi.universecorev2.subplugins.universeguns.menu.AmmoManagerInventoryMenu;
+import space.yurisi.universecorev2.subplugins.universeguns.menu.ammo_menu.AmmoManagerInventoryMenu;
 import space.yurisi.universecorev2.utils.Message;
 import xyz.xenondevs.invui.item.ItemProvider;
 import xyz.xenondevs.invui.item.builder.ItemBuilder;

--- a/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/menu/ammo_menu/item/AssaultRifleAmmoItem.java
+++ b/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/menu/ammo_menu/item/AssaultRifleAmmoItem.java
@@ -1,4 +1,4 @@
-package space.yurisi.universecorev2.subplugins.universeguns.menu.item;
+package space.yurisi.universecorev2.subplugins.universeguns.menu.ammo_menu.item;
 
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
@@ -7,44 +7,45 @@ import space.yurisi.universecorev2.exception.UserNotFoundException;
 import space.yurisi.universecorev2.subplugins.universeguns.connector.UniverseCoreAPIConnector;
 import space.yurisi.universecorev2.subplugins.universeguns.constants.GunType;
 
-public class SniperRifleAmmoItem extends AmmoItem {
+public class AssaultRifleAmmoItem extends AmmoItem {
 
-    public SniperRifleAmmoItem(UniverseCoreAPIConnector connector, int amount, Player player) {
+    public AssaultRifleAmmoItem(UniverseCoreAPIConnector connector, int amount, Player player) {
         super(connector, amount, player);
     }
 
     @Override
     protected Material getMaterial() {
-        return Material.BLUE_CARPET;
+        return Material.LIME_CARPET;
     }
 
     @Override
     protected String getDisplayName() {
-        return "スナイパーライフル";
+        return "アサルトライフル";
     }
 
     @Override
     protected long getCurrentAmmo() throws UserNotFoundException, AmmoNotFoundException {
-        return connector.getAmmoFromUserId(player, GunType.SR);
+        return connector.getAmmoFromUserId(player, GunType.AR);
     }
 
     @Override
     protected GunType getGunType() {
-        return GunType.SR;
+        return GunType.AR;
     }
 
     @Override
     protected int getAmountIron() {
-        return 3;
+        return 2;
     }
 
     @Override
     protected int getAmountPowder() {
-        return 3;
+        return 2;
     }
 
     @Override
     protected long getPrice() {
         return 300;
     }
+
 }

--- a/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/menu/ammo_menu/item/ExplosiveAmmoItem.java
+++ b/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/menu/ammo_menu/item/ExplosiveAmmoItem.java
@@ -1,4 +1,4 @@
-package space.yurisi.universecorev2.subplugins.universeguns.menu.item;
+package space.yurisi.universecorev2.subplugins.universeguns.menu.ammo_menu.item;
 
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
@@ -7,40 +7,40 @@ import space.yurisi.universecorev2.exception.UserNotFoundException;
 import space.yurisi.universecorev2.subplugins.universeguns.connector.UniverseCoreAPIConnector;
 import space.yurisi.universecorev2.subplugins.universeguns.constants.GunType;
 
-public class ShotGunAmmoItem extends AmmoItem {
+public class ExplosiveAmmoItem extends AmmoItem {
 
-    public ShotGunAmmoItem(UniverseCoreAPIConnector connector, int amount, Player player) {
+    public ExplosiveAmmoItem(UniverseCoreAPIConnector connector, int amount, Player player) {
         super(connector, amount, player);
     }
 
     @Override
     protected Material getMaterial() {
-        return Material.ORANGE_CARPET;
+        return Material.TNT;
     }
 
     @Override
     protected String getDisplayName() {
-        return "ショットガン";
+        return "特殊系";
     }
 
     @Override
     protected long getCurrentAmmo() throws UserNotFoundException, AmmoNotFoundException {
-        return connector.getAmmoFromUserId(player, GunType.SG);
+        return connector.getAmmoFromUserId(player, GunType.EX);
     }
 
     @Override
     protected GunType getGunType() {
-        return GunType.SG;
+        return GunType.EX;
     }
 
     @Override
     protected int getAmountIron() {
-        return 2;
+        return 4;
     }
 
     @Override
     protected int getAmountPowder() {
-        return 3;
+        return 5;
     }
 
     @Override

--- a/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/menu/ammo_menu/item/HandGunAmmoItem.java
+++ b/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/menu/ammo_menu/item/HandGunAmmoItem.java
@@ -1,4 +1,4 @@
-package space.yurisi.universecorev2.subplugins.universeguns.menu.item;
+package space.yurisi.universecorev2.subplugins.universeguns.menu.ammo_menu.item;
 
 import org.bukkit.Material;
 import org.bukkit.entity.Player;

--- a/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/menu/ammo_menu/item/LightMachineGunAmmoItem.java
+++ b/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/menu/ammo_menu/item/LightMachineGunAmmoItem.java
@@ -1,4 +1,4 @@
-package space.yurisi.universecorev2.subplugins.universeguns.menu.item;
+package space.yurisi.universecorev2.subplugins.universeguns.menu.ammo_menu.item;
 
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
@@ -7,40 +7,39 @@ import space.yurisi.universecorev2.exception.UserNotFoundException;
 import space.yurisi.universecorev2.subplugins.universeguns.connector.UniverseCoreAPIConnector;
 import space.yurisi.universecorev2.subplugins.universeguns.constants.GunType;
 
-public class ExplosiveAmmoItem extends AmmoItem {
-
-    public ExplosiveAmmoItem(UniverseCoreAPIConnector connector, int amount, Player player) {
+public class LightMachineGunAmmoItem extends AmmoItem {
+    public LightMachineGunAmmoItem(UniverseCoreAPIConnector connector, int amount, Player player) {
         super(connector, amount, player);
     }
 
     @Override
     protected Material getMaterial() {
-        return Material.TNT;
+        return Material.LIME_CARPET;
     }
 
     @Override
     protected String getDisplayName() {
-        return "特殊系";
+        return "軽機関銃";
     }
 
     @Override
     protected long getCurrentAmmo() throws UserNotFoundException, AmmoNotFoundException {
-        return connector.getAmmoFromUserId(player, GunType.EX);
+        return connector.getAmmoFromUserId(player, GunType.LMG);
     }
 
     @Override
     protected GunType getGunType() {
-        return GunType.EX;
+        return GunType.LMG;
     }
 
     @Override
     protected int getAmountIron() {
-        return 4;
+        return 3;
     }
 
     @Override
     protected int getAmountPowder() {
-        return 5;
+        return 4;
     }
 
     @Override

--- a/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/menu/ammo_menu/item/ShotGunAmmoItem.java
+++ b/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/menu/ammo_menu/item/ShotGunAmmoItem.java
@@ -1,50 +1,46 @@
-package space.yurisi.universecorev2.subplugins.universeguns.menu.item;
+package space.yurisi.universecorev2.subplugins.universeguns.menu.ammo_menu.item;
 
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
-import org.bukkit.event.inventory.ClickType;
-import org.bukkit.event.inventory.InventoryClickEvent;
-import org.jetbrains.annotations.NotNull;
 import space.yurisi.universecorev2.exception.AmmoNotFoundException;
 import space.yurisi.universecorev2.exception.UserNotFoundException;
 import space.yurisi.universecorev2.subplugins.universeguns.connector.UniverseCoreAPIConnector;
 import space.yurisi.universecorev2.subplugins.universeguns.constants.GunType;
-import space.yurisi.universecorev2.utils.Message;
 
-public class SubMachineGunAmmoItem extends AmmoItem {
+public class ShotGunAmmoItem extends AmmoItem {
 
-    public SubMachineGunAmmoItem(UniverseCoreAPIConnector connector, int amount, Player player) {
+    public ShotGunAmmoItem(UniverseCoreAPIConnector connector, int amount, Player player) {
         super(connector, amount, player);
     }
 
     @Override
     protected Material getMaterial() {
-        return Material.LIME_CARPET;
+        return Material.ORANGE_CARPET;
     }
 
     @Override
     protected String getDisplayName() {
-        return "サブマシンガン";
+        return "ショットガン";
     }
 
     @Override
     protected long getCurrentAmmo() throws UserNotFoundException, AmmoNotFoundException {
-        return connector.getAmmoFromUserId(player, GunType.SMG);
+        return connector.getAmmoFromUserId(player, GunType.SG);
     }
 
     @Override
     protected GunType getGunType() {
-        return GunType.SMG;
+        return GunType.SG;
     }
 
     @Override
     protected int getAmountIron() {
-        return 1;
+        return 2;
     }
 
     @Override
     protected int getAmountPowder() {
-        return 2;
+        return 3;
     }
 
     @Override

--- a/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/menu/ammo_menu/item/SniperRifleAmmoItem.java
+++ b/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/menu/ammo_menu/item/SniperRifleAmmoItem.java
@@ -1,4 +1,4 @@
-package space.yurisi.universecorev2.subplugins.universeguns.menu.item;
+package space.yurisi.universecorev2.subplugins.universeguns.menu.ammo_menu.item;
 
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
@@ -7,45 +7,44 @@ import space.yurisi.universecorev2.exception.UserNotFoundException;
 import space.yurisi.universecorev2.subplugins.universeguns.connector.UniverseCoreAPIConnector;
 import space.yurisi.universecorev2.subplugins.universeguns.constants.GunType;
 
-public class AssaultRifleAmmoItem extends AmmoItem {
+public class SniperRifleAmmoItem extends AmmoItem {
 
-    public AssaultRifleAmmoItem(UniverseCoreAPIConnector connector, int amount, Player player) {
+    public SniperRifleAmmoItem(UniverseCoreAPIConnector connector, int amount, Player player) {
         super(connector, amount, player);
     }
 
     @Override
     protected Material getMaterial() {
-        return Material.LIME_CARPET;
+        return Material.BLUE_CARPET;
     }
 
     @Override
     protected String getDisplayName() {
-        return "アサルトライフル";
+        return "スナイパーライフル";
     }
 
     @Override
     protected long getCurrentAmmo() throws UserNotFoundException, AmmoNotFoundException {
-        return connector.getAmmoFromUserId(player, GunType.AR);
+        return connector.getAmmoFromUserId(player, GunType.SR);
     }
 
     @Override
     protected GunType getGunType() {
-        return GunType.AR;
+        return GunType.SR;
     }
 
     @Override
     protected int getAmountIron() {
-        return 2;
+        return 3;
     }
 
     @Override
     protected int getAmountPowder() {
-        return 2;
+        return 3;
     }
 
     @Override
     protected long getPrice() {
         return 300;
     }
-
 }

--- a/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/menu/ammo_menu/item/SubMachineGunAmmoItem.java
+++ b/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/menu/ammo_menu/item/SubMachineGunAmmoItem.java
@@ -1,4 +1,4 @@
-package space.yurisi.universecorev2.subplugins.universeguns.menu.item;
+package space.yurisi.universecorev2.subplugins.universeguns.menu.ammo_menu.item;
 
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
@@ -7,8 +7,9 @@ import space.yurisi.universecorev2.exception.UserNotFoundException;
 import space.yurisi.universecorev2.subplugins.universeguns.connector.UniverseCoreAPIConnector;
 import space.yurisi.universecorev2.subplugins.universeguns.constants.GunType;
 
-public class LightMachineGunAmmoItem extends AmmoItem {
-    public LightMachineGunAmmoItem(UniverseCoreAPIConnector connector, int amount, Player player) {
+public class SubMachineGunAmmoItem extends AmmoItem {
+
+    public SubMachineGunAmmoItem(UniverseCoreAPIConnector connector, int amount, Player player) {
         super(connector, amount, player);
     }
 
@@ -19,27 +20,27 @@ public class LightMachineGunAmmoItem extends AmmoItem {
 
     @Override
     protected String getDisplayName() {
-        return "軽機関銃";
+        return "サブマシンガン";
     }
 
     @Override
     protected long getCurrentAmmo() throws UserNotFoundException, AmmoNotFoundException {
-        return connector.getAmmoFromUserId(player, GunType.LMG);
+        return connector.getAmmoFromUserId(player, GunType.SMG);
     }
 
     @Override
     protected GunType getGunType() {
-        return GunType.LMG;
+        return GunType.SMG;
     }
 
     @Override
     protected int getAmountIron() {
-        return 3;
+        return 1;
     }
 
     @Override
     protected int getAmountPowder() {
-        return 4;
+        return 2;
     }
 
     @Override

--- a/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/menu/shop_menu/AssultRifleShopMenu.java
+++ b/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/menu/shop_menu/AssultRifleShopMenu.java
@@ -1,0 +1,41 @@
+package space.yurisi.universecorev2.subplugins.universeguns.menu.shop_menu;
+
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import space.yurisi.universecorev2.item.gun.*;
+import space.yurisi.universecorev2.menu.BaseMenu;
+import space.yurisi.universecorev2.subplugins.universeguns.menu.shop_menu.item.GunShopMenuItem;
+import xyz.xenondevs.invui.gui.Gui;
+import xyz.xenondevs.invui.item.Item;
+import xyz.xenondevs.invui.item.builder.ItemBuilder;
+import xyz.xenondevs.invui.item.impl.SimpleItem;
+import xyz.xenondevs.invui.window.Window;
+
+public class AssultRifleShopMenu implements BaseMenu {
+
+    public AssultRifleShopMenu() {
+    }
+
+    public void sendMenu(Player player) {
+
+        Item border = new SimpleItem(new ItemBuilder(Material.AIR));
+
+        Gui.Builder.@NotNull Normal gui = Gui.normal()
+                .setStructure(
+                        "a b # # # # # # #")
+                .addIngredient('#', border)
+
+                .addIngredient('a', new GunShopMenuItem(new R4C()))
+                .addIngredient('b', new GunShopMenuItem(new F2()));
+
+
+        xyz.xenondevs.invui.window.Window window = Window.single()
+                .setViewer(player)
+                .setGui(gui.build())
+                .setTitle("アサルトライフル")
+                .build();
+
+        window.open();
+    }
+}

--- a/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/menu/shop_menu/ExplosiveShopMenu.java
+++ b/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/menu/shop_menu/ExplosiveShopMenu.java
@@ -1,0 +1,39 @@
+package space.yurisi.universecorev2.subplugins.universeguns.menu.shop_menu;
+
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import space.yurisi.universecorev2.item.gun.*;
+import space.yurisi.universecorev2.menu.BaseMenu;
+import space.yurisi.universecorev2.subplugins.universeguns.menu.shop_menu.item.GunShopMenuItem;
+import xyz.xenondevs.invui.gui.Gui;
+import xyz.xenondevs.invui.item.Item;
+import xyz.xenondevs.invui.item.builder.ItemBuilder;
+import xyz.xenondevs.invui.item.impl.SimpleItem;
+import xyz.xenondevs.invui.window.Window;
+
+public class ExplosiveShopMenu implements BaseMenu{
+
+    public ExplosiveShopMenu() {
+    }
+
+    public void sendMenu(Player player) {
+
+        Item border = new SimpleItem(new ItemBuilder(Material.AIR));
+
+        Gui.Builder.@NotNull Normal gui = Gui.normal()
+                .setStructure(
+                        "a # # # # # # # #")
+                .addIngredient('#', border)
+
+                .addIngredient('a', new GunShopMenuItem(new RPG()));
+
+        xyz.xenondevs.invui.window.Window window = Window.single()
+                .setViewer(player)
+                .setGui(gui.build())
+                .setTitle("特殊武器")
+                .build();
+
+        window.open();
+    }
+}

--- a/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/menu/shop_menu/HandGunShopMenu.java
+++ b/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/menu/shop_menu/HandGunShopMenu.java
@@ -1,0 +1,39 @@
+package space.yurisi.universecorev2.subplugins.universeguns.menu.shop_menu;
+
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import space.yurisi.universecorev2.item.gun.*;
+import space.yurisi.universecorev2.menu.BaseMenu;
+import space.yurisi.universecorev2.subplugins.universeguns.menu.shop_menu.item.GunShopMenuItem;
+import xyz.xenondevs.invui.gui.Gui;
+import xyz.xenondevs.invui.item.Item;
+import xyz.xenondevs.invui.item.builder.ItemBuilder;
+import xyz.xenondevs.invui.item.impl.SimpleItem;
+import xyz.xenondevs.invui.window.Window;
+
+public class HandGunShopMenu implements BaseMenu {
+
+    public HandGunShopMenu() {
+    }
+
+    public void sendMenu(Player player) {
+
+        Item border = new SimpleItem(new ItemBuilder(Material.AIR));
+
+        Gui.Builder.@NotNull Normal gui = Gui.normal()
+                .setStructure(
+                        "a # # # # # # # #")
+                .addIngredient('#', border)
+
+                .addIngredient('a', new GunShopMenuItem(new M1911()));
+
+        xyz.xenondevs.invui.window.Window window = Window.single()
+                .setViewer(player)
+                .setGui(gui.build())
+                .setTitle("ハンドガン")
+                .build();
+
+        window.open();
+    }
+}

--- a/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/menu/shop_menu/LightMachineGunShopMenu.java
+++ b/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/menu/shop_menu/LightMachineGunShopMenu.java
@@ -1,0 +1,37 @@
+package space.yurisi.universecorev2.subplugins.universeguns.menu.shop_menu;
+
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import space.yurisi.universecorev2.item.gun.*;
+import space.yurisi.universecorev2.menu.BaseMenu;
+import space.yurisi.universecorev2.subplugins.universeguns.menu.shop_menu.item.GunShopMenuItem;
+import xyz.xenondevs.invui.gui.Gui;
+import xyz.xenondevs.invui.item.Item;
+import xyz.xenondevs.invui.item.builder.ItemBuilder;
+import xyz.xenondevs.invui.item.impl.SimpleItem;
+import xyz.xenondevs.invui.window.Window;
+
+public class LightMachineGunShopMenu implements BaseMenu{
+
+    public LightMachineGunShopMenu() {
+    }
+
+    public void sendMenu(Player player) {
+
+        Item border = new SimpleItem(new ItemBuilder(Material.AIR));
+
+        Gui.Builder.@NotNull Normal gui = Gui.normal()
+                .setStructure(
+                        "# # # # # # # # #")
+                .addIngredient('#', border);
+
+        xyz.xenondevs.invui.window.Window window = Window.single()
+                .setViewer(player)
+                .setGui(gui.build())
+                .setTitle("軽機関銃")
+                .build();
+
+        window.open();
+    }
+}

--- a/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/menu/shop_menu/ShotGunShopMenu.java
+++ b/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/menu/shop_menu/ShotGunShopMenu.java
@@ -1,0 +1,39 @@
+package space.yurisi.universecorev2.subplugins.universeguns.menu.shop_menu;
+
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import space.yurisi.universecorev2.item.gun.*;
+import space.yurisi.universecorev2.menu.BaseMenu;
+import space.yurisi.universecorev2.subplugins.universeguns.menu.shop_menu.item.GunShopMenuItem;
+import xyz.xenondevs.invui.gui.Gui;
+import xyz.xenondevs.invui.item.Item;
+import xyz.xenondevs.invui.item.builder.ItemBuilder;
+import xyz.xenondevs.invui.item.impl.SimpleItem;
+import xyz.xenondevs.invui.window.Window;
+
+public class ShotGunShopMenu implements BaseMenu{
+
+    public ShotGunShopMenu() {
+    }
+
+    public void sendMenu(Player player) {
+
+        Item border = new SimpleItem(new ItemBuilder(Material.AIR));
+
+        Gui.Builder.@NotNull Normal gui = Gui.normal()
+                .setStructure(
+                        "a # # # # # # # #")
+                .addIngredient('#', border)
+
+                .addIngredient('a', new GunShopMenuItem(new M870()));
+
+        xyz.xenondevs.invui.window.Window window = Window.single()
+                .setViewer(player)
+                .setGui(gui.build())
+                .setTitle("ショットガン")
+                .build();
+
+        window.open();
+    }
+}

--- a/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/menu/shop_menu/SniperRifleShopMenu.java
+++ b/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/menu/shop_menu/SniperRifleShopMenu.java
@@ -1,0 +1,39 @@
+package space.yurisi.universecorev2.subplugins.universeguns.menu.shop_menu;
+
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import space.yurisi.universecorev2.item.gun.*;
+import space.yurisi.universecorev2.menu.BaseMenu;
+import space.yurisi.universecorev2.subplugins.universeguns.menu.shop_menu.item.GunShopMenuItem;
+import xyz.xenondevs.invui.gui.Gui;
+import xyz.xenondevs.invui.item.Item;
+import xyz.xenondevs.invui.item.builder.ItemBuilder;
+import xyz.xenondevs.invui.item.impl.SimpleItem;
+import xyz.xenondevs.invui.window.Window;
+
+public class SniperRifleShopMenu implements BaseMenu{
+
+    public SniperRifleShopMenu() {
+    }
+
+    public void sendMenu(Player player) {
+
+        Item border = new SimpleItem(new ItemBuilder(Material.AIR));
+
+        Gui.Builder.@NotNull Normal gui = Gui.normal()
+                .setStructure(
+                        "a # # # # # # # #")
+                .addIngredient('#', border)
+
+                .addIngredient('a', new GunShopMenuItem(new L96A1()));
+
+        xyz.xenondevs.invui.window.Window window = Window.single()
+                .setViewer(player)
+                .setGui(gui.build())
+                .setTitle("スナイパーライフル")
+                .build();
+
+        window.open();
+    }
+}

--- a/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/menu/shop_menu/SubMachineGunShopMenu.java
+++ b/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/menu/shop_menu/SubMachineGunShopMenu.java
@@ -1,0 +1,39 @@
+package space.yurisi.universecorev2.subplugins.universeguns.menu.shop_menu;
+
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import space.yurisi.universecorev2.item.gun.*;
+import space.yurisi.universecorev2.menu.BaseMenu;
+import space.yurisi.universecorev2.subplugins.universeguns.menu.shop_menu.item.GunShopMenuItem;
+import xyz.xenondevs.invui.gui.Gui;
+import xyz.xenondevs.invui.item.Item;
+import xyz.xenondevs.invui.item.builder.ItemBuilder;
+import xyz.xenondevs.invui.item.impl.SimpleItem;
+import xyz.xenondevs.invui.window.Window;
+
+public class SubMachineGunShopMenu implements BaseMenu {
+
+    public SubMachineGunShopMenu() {
+    }
+
+    public void sendMenu(Player player) {
+
+        Item border = new SimpleItem(new ItemBuilder(Material.AIR));
+
+        Gui.Builder.@NotNull Normal gui = Gui.normal()
+                .setStructure(
+                        "a # # # # # # # #")
+                .addIngredient('#', border)
+
+                .addIngredient('a', new GunShopMenuItem(new SMG11()));
+
+        xyz.xenondevs.invui.window.Window window = Window.single()
+                .setViewer(player)
+                .setGui(gui.build())
+                .setTitle("サブマシンガン")
+                .build();
+
+        window.open();
+    }
+}

--- a/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/menu/shop_menu/item/GunShopMenuItem.java
+++ b/src/main/java/space/yurisi/universecorev2/subplugins/universeguns/menu/shop_menu/item/GunShopMenuItem.java
@@ -1,0 +1,49 @@
+package space.yurisi.universecorev2.subplugins.universeguns.menu.shop_menu.item;
+
+import net.kyori.adventure.text.Component;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.ClickType;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.jetbrains.annotations.NotNull;
+import space.yurisi.universecorev2.item.gun.Gun;
+import space.yurisi.universecorev2.subplugins.universeguns.core.PurchaseGun;
+import xyz.xenondevs.invui.item.ItemProvider;
+import xyz.xenondevs.invui.item.builder.ItemBuilder;
+import xyz.xenondevs.invui.item.impl.AbstractItem;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class GunShopMenuItem extends AbstractItem {
+
+    private final Gun gun;
+
+    public GunShopMenuItem(Gun gun) {
+        this.gun = gun;
+    }
+
+    @Override
+    public ItemProvider getItemProvider() {
+        ItemStack itemStack = new ItemStack(Material.DIAMOND_HOE);
+        ItemMeta itemMeta = itemStack.getItemMeta();
+        if(itemMeta != null) {
+            itemMeta.setCustomModelData(gun.getTextureNumber());
+            itemMeta.setDisplayName(gun.getName());
+            List<Component> lore = new ArrayList<>(gun.getGunComponents());
+            lore.add(Component.text(gun.getFlavorText()));
+            lore.add(Component.text("§7値段: §b" + gun.getPrice() + "§7枚"));
+            lore.add(Component.text("§7クリックで購入"));
+            itemMeta.lore(lore);
+            itemStack.setItemMeta(itemMeta);
+        }
+        return new ItemBuilder(itemStack);
+    }
+
+    @Override
+    public void handleClick(@NotNull ClickType clickType, @NotNull Player player, @NotNull InventoryClickEvent event) {
+        PurchaseGun.executePurchase(player, gun);
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -99,6 +99,10 @@ commands:
   ## UniverseGuns
   ammo:
     description: 弾薬管理メニューを開く
+  spawnGunClerk:
+    description: 銃ショップの店員召喚
+  killGunClerk:
+    description: 半径5ブロック以内の指定したショップの店員を排除します
 
   ## PlayerHead
   head:


### PR DESCRIPTION
銃ショップを実装　値段は適当
貨幣である銃チケットの入手方法は未実装(ガチャ、殺害時にランダム入手などを想定)

フレーバーテキストはショップでのみ表示されるように変更
ショップ店員の召喚・殺害コマンド実装


UniverseItemのremoveItemを複数個消費できるように変更
giveu ticket のコマンドで銃チケットを召喚できるよう引数を追加
例)
giveu ticket gacha 23
giveu ticket gun 64　