### PR TITLE
fix player nameplate prefix and color sync issue

### DIFF
--- a/src/main/java/space/yurisi/universecorev2/subplugins/playerinfoscoreboard/task/ScoreBoardTask.java
+++ b/src/main/java/space/yurisi/universecorev2/subplugins/playerinfoscoreboard/task/ScoreBoardTask.java
@@ -27,7 +27,7 @@ public final class ScoreBoardTask extends BukkitRunnable {
     public ScoreBoardTask(Player player) {
         this.player = player;
 
-        if (player.getScoreboard() == Bukkit.getScoreboardManager().getMainScoreboard()) {
+        if (player.getScoreboard().equals(Bukkit.getScoreboardManager().getMainScoreboard())) {
             player.setScoreboard(Bukkit.getScoreboardManager().getNewScoreboard());
         }
     }


### PR DESCRIPTION
これは将来的にネームタグをパケットをいじって頭上の名前を変えるのではなく、標準機能であるTeamのPrefixを活用する場合に適したPRと、ちょっとしたリファクタリングが含まれてる