### PR TITLE
クリーパーやTNTの爆発によって防具立てが破壊される問題を修正

### DIFF
--- a/src/main/java/space/yurisi/universecorev2/event/entity/EntityHangingBreakEvent.java
+++ b/src/main/java/space/yurisi/universecorev2/event/entity/EntityHangingBreakEvent.java
@@ -7,22 +7,20 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.hanging.HangingBreakByEntityEvent;
 import org.bukkit.event.hanging.HangingBreakEvent;
+import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 
 public class EntityHangingBreakEvent implements Listener {
     @EventHandler(priority = EventPriority.HIGH)
     public void onHanging(HangingBreakByEntityEvent event) {
-        if(event.getCause() == HangingBreakEvent.RemoveCause.EXPLOSION){
-            event.setCancelled(true);
-        }
+        event.setCancelled(event.getCause() == HangingBreakEvent.RemoveCause.EXPLOSION);
     }
 
     @EventHandler(priority = EventPriority.HIGH)
     public void onDamage(EntityDamageEvent event) {
         if (event.getEntityType() == EntityType.ARMOR_STAND) {
-            if (event.getCause() == EntityDamageEvent.DamageCause.ENTITY_EXPLOSION ||
-                    event.getCause() == EntityDamageEvent.DamageCause.BLOCK_EXPLOSION) {
-                event.setCancelled(true);
-            }
+            DamageCause damageCause = event.getCause();
+            // エンティティへのダメージソースが，エンティティかブロック起因だった場合はキャンセルする
+            event.setCancelled(damageCause == DamageCause.ENTITY_EXPLOSION || damageCause == DamageCause.BLOCK_EXPLOSION);
         }
     }
 }


### PR DESCRIPTION
水流で流れている時や防具、プレイヤーヘッドをつけている時でも壊れないことを確認済
既存であった額縁や絵画も壊れないことも確認済