### PR TITLE
スロットに対してホッパーで不正できるバグの修正

### DIFF
--- a/src/main/java/space/yurisi/universecorev2/subplugins/universeslot/command/SlotCommand.java
+++ b/src/main/java/space/yurisi/universecorev2/subplugins/universeslot/command/SlotCommand.java
@@ -54,20 +54,21 @@ public class SlotCommand implements CommandExecutor, TabCompleter {
         }
 
         UniverseSlot main = UniverseSlot.getInstance();
+        PlayerStatusManager playerStatusManager = main.getPlayerStatusManager();
 
         // スロット編集モードの切り替え
         if(args[0].equals("edit")) {
-            if (main.getPlayerStatusManager().hasFlag(player.getUniqueId(), PlayerStatusManager.ON_EDIT_MODE)) {
-                main.getPlayerStatusManager().removeFlag(player.getUniqueId(), PlayerStatusManager.ON_EDIT_MODE);
+            if (playerStatusManager.hasFlag(player.getUniqueId(), PlayerStatusManager.ON_EDIT_MODE)) {
+                playerStatusManager.removeFlag(player.getUniqueId(), PlayerStatusManager.ON_EDIT_MODE);
+                playerStatusManager.removeClickedLocation(player.getUniqueId());
                 Message.sendNormalMessage(player, "[スロットAI]", "スロット編集モードを解除しました。");
             } else {
-                main.getPlayerStatusManager().addFlag(player.getUniqueId(), PlayerStatusManager.ON_EDIT_MODE);
+                playerStatusManager.addFlag(player.getUniqueId(), PlayerStatusManager.ON_EDIT_MODE);
                 Message.sendSuccessMessage(player, "[スロットAI]", "スロット編集モードに入りました。");
             }
             return true;
         }
 
-        PlayerStatusManager playerStatusManager = main.getPlayerStatusManager();
         SlotLocationManager slotLocationManager = main.getSlotLocationManager();
         SlotRepository slotRepository = UniverseCoreV2API.getInstance().getDatabaseManagerV2().get(SlotRepository.class);
 

--- a/src/main/java/space/yurisi/universecorev2/subplugins/universeslot/listener/EventManager.java
+++ b/src/main/java/space/yurisi/universecorev2/subplugins/universeslot/listener/EventManager.java
@@ -3,6 +3,7 @@ package space.yurisi.universecorev2.subplugins.universeslot.listener;
 import space.yurisi.universecorev2.UniverseCoreV2;
 import space.yurisi.universecorev2.subplugins.universeslot.UniverseSlot;
 import space.yurisi.universecorev2.subplugins.universeslot.listener.block.BreakEvent;
+import space.yurisi.universecorev2.subplugins.universeslot.listener.block.HopperPlaceProtect;
 import space.yurisi.universecorev2.subplugins.universeslot.listener.block.ShelfInteractEvent;
 import space.yurisi.universecorev2.subplugins.universeslot.listener.block.SlotEditEvent;
 import space.yurisi.universecorev2.subplugins.universeslot.listener.player.LogoutEvent;
@@ -22,5 +23,6 @@ public class EventManager {
         core.getServer().getPluginManager().registerEvents(new BreakEvent(), core);
         core.getServer().getPluginManager().registerEvents(new SlotPlayerMoveEvent(), core);
         core.getServer().getPluginManager().registerEvents(new SlotPlayerTeleportEvent(), core);
+        core.getServer().getPluginManager().registerEvents(new HopperPlaceProtect(), core);
     }
 }

--- a/src/main/java/space/yurisi/universecorev2/subplugins/universeslot/listener/block/HopperPlaceProtect.java
+++ b/src/main/java/space/yurisi/universecorev2/subplugins/universeslot/listener/block/HopperPlaceProtect.java
@@ -1,0 +1,49 @@
+package space.yurisi.universecorev2.subplugins.universeslot.listener.block;
+
+import org.bukkit.Location;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockType;
+import org.bukkit.block.Shelf;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.event.inventory.InventoryMoveItemEvent;
+import org.bukkit.inventory.InventoryHolder;
+
+public class HopperPlaceProtect implements Listener {
+
+    @EventHandler
+    public void onBlockPlace(BlockPlaceEvent event) {
+        BlockType blockType = event.getBlock().getType().asBlockType();
+        if (blockType != BlockType.HOPPER) {
+            return;
+        }
+
+        // 周り8ブロックをチェックし棚がある場合はキャンセル
+        for (int dx = -1; dx <= 1; dx++) {
+            for (int dy = -1; dy <= 1; dy++) {
+                for (int dz = -1; dz <= 1; dz++) {
+
+                    if(event.getBlock().getRelative(dx, dy, dz).getState() instanceof Shelf) {
+                        event.setCancelled(true);
+                        return;
+                    }
+                }
+            }
+        }
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onHopperSearch(InventoryMoveItemEvent event) {
+        // ホッパートロッコ対策
+        if(event.getSource().getHolder() instanceof InventoryHolder holder) {
+            Location location = holder.getInventory().getLocation();
+            if(location == null) return;
+            Block block = location.getBlock();
+            if(block.getState() instanceof Shelf) {
+                event.setCancelled(true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
そもそもおけなくしたのとInventortMoveItemEventでブロックした
あとスロット編集モードを解除してもinfoとかできてしまうのを防いだ